### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PERSISTENT_VOLUME_DIRS=(code puppet puppetdb/ssl puppetdb-postgres serverdata)
+
+echo "Creating directories for persistent volumes..."
+mkdir -p "${PERSISTENT_VOLUME_DIRS[*]}"
+
+echo
+
+echo "On OSX, you must now add all of the following directories to your Docker>Preferences>File Sharing:"
+echo "${PERSISTENT_VOLUME_DIRS[*]}"


### PR DESCRIPTION
This commit adds a `setup.sh` script that will add the required
directories for setting up the persistent volumes. I added this
because on OSX, the docker compose up will just fail due to the
directories being missing.