### PR TITLE
Add k8s support

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,82 @@
+# pupperware in Kubernetes
+
+**EXPERIMENTAL**
+
+The k8s YAML files contained within were created with Minikube & Docker for Mac in mind, should be considered experimental, and are not appropriate for most deployments.
+
+## Quick Start
+
+To get started, you will need an Kubernetes cluster at your disposal with [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) configured correctly to communicate with your cluster.
+If you do not have a cluster avaiable, [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) will allow you to run a single-node Kubernetes cluster on your local machine.
+
+Modify the `DNS_ALT_NAMES` value in [`puppetserver.yaml`](puppetserver.yaml) to contain the DNS names (as a comma-delimited list) of the Kubernetes node that will run the Pupper server pod. If you are
+running Kubernetes via Docker for Mac, this will be the FQDN of your Mac. Note that `puppet` is required for Puppet server and PuppetDB to communicate.
+
+```yaml
+  - name: DNS_ALT_NAMES
+    value: puppet,myworkstation.domain.net
+```
+
+Then create the Pupperware resources:
+
+```bash
+$ kubectl create -f k8s/secrets.yaml -f k8s/postgres.yaml -f k8s/puppetserver.yaml -f k8s/puppetdb.yaml
+```
+
+### Connecting Nodes
+
+Kubernetes will expose the Puppet server port (normally TCP port `8140`) on the Kubernetes node using the `NodePort` service type. By default, the TCP port chosen will range from 30000-32767.
+Refer to the [Kubernetes documentation on NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) for more information.
+
+To find the port number, run `kubectl get svc/puppet`:
+
+```bash
+$ kubectl get svc/puppet
+NAME       TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+puppet     NodePort   10.106.50.178   <none>        8140:32520/TCP   1m
+```
+
+In the example above, the Puppet Server service running on port `8140` has been exposed on the Kubernetes node via port `32520`. Assuming the Kubernetes node's FQDN is
+`myworkstation.domain.net`, the following commands will configure a Puppet agent to communicate successfully to the Puppet Server.
+
+```bash
+$ puppet config set server myworkstation.domain.net
+$ puppet config set masterport 32520
+```
+
+## Management
+
+### Running puppet commands
+
+Use the scripts `k8s/bin/puppet` and `k8s/bin/puppetsever` to run commands on the Puppet master. For example, to list all of the certificates using the Puppet 6 CA command,
+run `./k8s/bin/puppetserver ca list --all`.
+
+### Running PuppetDB queries
+
+The script `k8s/bin/puppet-query` may be used to run Puppet queries against PuppetDB.
+
+`./k8s/bin/puppet-query 'nodes[certname]{}'`
+
+### Changing postgresql password
+
+The credentials for postgresql are stored within the [`secrets.yaml` file](secrets.yaml) as a base64 encoded string. Replace the string with the desired base64-encoded password.
+
+```bash
+$ echo -n "password123" | base64
+cGFzc3dvcmQxMjM=
+```
+
+### Deleting Pupperware resources
+
+*Warning*: This will completely remove all resources from Kubernetes, including PuppetDB, SSL certificates, and Puppet code.
+
+```bash
+$ kubectl delete -f k8s/secrets.yaml -f k8s/postgres.yaml -f k8s/puppetserver.yaml -f k8s/puppetdb.yaml
+```
+
+## To-Do
+
+- [ ] Create a more realistic service option using the `LoadBalancer` service type and/or Ingress
+- [ ] Provide a mechanism to configure r10k & deploy code
+- [ ] Create a configuration that uses local volumes to more closely mimic `docker-compose`
+- [ ] Use k8s' functions to scale out the infrastructure with additional compile masters (difficult)

--- a/k8s/bin/puppet
+++ b/k8s/bin/puppet
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+kubectl get pods --selector=svc=puppet -o name | cut -d '/' -f 2 | xargs -I '{}' kubectl exec '{}' -- puppet "$@"

--- a/k8s/bin/puppet-query
+++ b/k8s/bin/puppet-query
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+kubectl get pods --selector=svc=puppetdb -o name | cut -d '/' -f 2 | xargs -I '%' kubectl exec '%' -- curl -s -X GET http://puppetdb:8080/pdb/query/v4 --data-urlencode "query=$@"

--- a/k8s/bin/puppetserver
+++ b/k8s/bin/puppetserver
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+kubectl get pods --selector=svc=puppet -o name | cut -d '/' -f 2 | xargs -I '{}' kubectl exec '{}' -- puppetserver "$@"

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: pupperware
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: pupperware
+    svc: postgres
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-claim
+  labels:
+    app: pupperware
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: pupperware
+spec:
+  selector:
+    matchLabels:
+      app: pupperware
+      svc: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: pupperware
+        svc: postgres
+    spec:
+      containers:
+        - image: puppet/puppetdb-postgres
+          name: postgres
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: puppetdb
+                  key: password
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: puppetdb
+                  key: user
+          ports:
+            - name: postgres
+              containerPort: 5432
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data/
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-claim

--- a/k8s/puppetdb.yaml
+++ b/k8s/puppetdb.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: puppetdb
+  labels:
+    app: pupperware
+spec:
+  ports:
+    - name: "pdb-http"
+      port: 8080
+    - name: "pdb-https"
+      port: 8081
+  selector:
+    app: pupperware
+    svc: puppetdb
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: puppetdb-claim
+  labels:
+    app: pupperware
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puppetdb
+  labels:
+    app: pupperware
+spec:
+  selector:
+    matchLabels:
+      app: pupperware
+      svc: puppetdb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: pupperware
+        svc: puppetdb
+    spec:
+      hostname: puppetdb
+      containers:
+        - image: puppet/puppetdb
+          name: puppetdb
+          env:
+            - name: PUPPETDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: puppetdb
+                  key: password
+            - name: PUPPETDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: puppetdb
+                  key: user
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+          volumeMounts:
+            - name: puppetdb-storage
+              mountPath: /etc/puppetlabs/puppet/ssl/
+      volumes:
+        - name: puppetdb-storage
+          persistentVolumeClaim:
+            claimName: puppetdb-claim

--- a/k8s/puppetserver.yaml
+++ b/k8s/puppetserver.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: puppet
+  labels:
+    app: pupperware
+spec:
+  ports:
+    - port: 8140
+  selector:
+    app: pupperware
+    svc: puppet
+  type: NodePort
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: puppet-code-claim
+  labels:
+    app: pupperware
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: puppet-serverdata-claim
+  labels:
+    app: pupperware
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: puppet-puppet-claim
+  labels:
+    app: pupperware
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puppet
+  labels:
+    app: pupperware
+spec:
+  selector:
+    matchLabels:
+      app: pupperware
+      svc: puppet
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: pupperware
+        svc: puppet
+    spec:
+      hostname: puppet
+      containers:
+        - image: puppet/puppetserver
+          name: puppet
+          env:
+            - name: DNS_ALT_NAMES
+              value: puppet
+            - name: PUPPETDB_SERVER_URLS
+              value: https://puppetdb:8081
+          ports:
+            - containerPort: 8140
+          volumeMounts:
+            - name: puppet-code-storage
+              mountPath: /etc/puppetlabs/code/
+            - name: puppet-puppet-storage
+              mountPath: /etc/puppetlabs/puppet/
+            - name: puppet-serverdata-storage
+              mountPath: /opt/puppetlabs/server/data/puppetserver/
+      volumes:
+        - name: puppet-code-storage
+          persistentVolumeClaim:
+            claimName: puppet-code-claim
+        - name: puppet-puppet-storage
+          persistentVolumeClaim:
+            claimName: puppet-puppet-claim
+        - name: puppet-serverdata-storage
+          persistentVolumeClaim:
+            claimName: puppet-serverdata-claim

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: puppetdb
+  labels:
+    app: pupperware
+type: Opaque
+data:
+  # puppetdb / puppetdb
+  user: cHVwcGV0ZGI=
+  password: cHVwcGV0ZGI=


### PR DESCRIPTION
This is essentially a Kubernetes version of Pupperware.

I am definitely not a Kubernetes master, so suggestions/questions/feedback/etc are welcomed.

Quick Start:
1. Modify the `DNS_ALT_NAMES`'s value 
 https://github.com/puppetlabs/pupperware/blob/d1e9e5c8f0bc4e588815e68c5a290f2a3a956b9f/k8s/puppetserver.yaml#L79-L80
2. `kubectl create -f k8s/secrets.yaml -f k8s/postgres.yaml -f k8s/puppetserver.yaml -f k8s/puppetdb.yaml`
3. Currently this is setup with Minikube support in mind, therefore Puppet Server's 8140 port will bind to a port on the host node in the 30000 range utilizing k8s' `NodePort` function. External agents will need their configuration changed to talk on the correct port (ie. `puppet agent -t --masterport=32024`). In a "real" scenario, a load balancer should probably be used instead.