### PR TITLE
(MAINT) Always include "puppet" as DNS_ALT_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ which you will run your Puppet Infrastructure.
 
 Once you have Docker Compose installed, you can start the stack on Linux with:
 ```
-    DNS_ALT_NAMES=puppet,host.exmple.com docker-compose up -d
+    DNS_ALT_NAMES=host.example.com docker-compose up -d
 ```
 
 The value of `DNS_ALT_NAMES` must list all the names, as a comma-separated
 list, under which the Puppet server in the stack can be reached from
-agents. It must include `puppet` as that is used by PuppetDB to communicate
-with the Puppet server. The value of `DNS_ALT_NAMES` only has an effect the
-first time you start the stack, as it is placed into the server's SSL
+agents. It will have `puppet` prepended to it as that name is used by PuppetDB
+to communicate with the Puppet server. The value of `DNS_ALT_NAMES` only has an
+effect the first time you start the stack, as it is placed into the server's SSL
 certificate. If you need to change it after that, you will need to properly
 revoke the server's certificate and restart the stack with the changed
 `DNS_ALT_NAMES` value.
@@ -51,7 +51,7 @@ Due to [permissions issues with Postgres](https://forums.docker.com/t/trying-to-
 To create the stack:
 
 ``` powershell
-PS> $ENV:DNS_ALT_NAMES = 'puppet,host.exmple.com'
+PS> $ENV:DNS_ALT_NAMES = 'host.example.com'
 
 PS> docker-compose -f .\docker-compose.yml -f .\docker-compose.windows.yml up
 Creating network "pupperware_default" with the default driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # and must list all the names under which the puppetserver can be
       # reached. 'puppet' must be one of them, otherwise puppetdb won't be
       # able to get a cert. Add other names as a comma-separated list
-      - DNS_ALT_NAMES
+      - DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
       - ./volumes/code:/etc/puppetlabs/code/


### PR DESCRIPTION
Since this is a required value we can just hardcode it into the compose
file and let the user supply additional DNS alt names.

Reference: https://docs.docker.com/compose/environment-variables/