### PR TITLE
(MAINT) Add root directory for persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-persistence/
+volumes/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-code/
-puppet/
-puppetdb/
-puppetdb-postgres/
-serverdata/
+persistence/

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ revoke the server's certificate and restart the stack with the changed
 `DNS_ALT_NAMES` value.
 
 When you first start the Puppet Infrastructure, the stack will create a
-number of directories to store the persistent data that should survive the
-restart of your infrastructure. These directories are created right next to
-the Docker Compose file:
+`persistence/` directory with a number of sub-directories to store the
+persistent data that should survive the restart of your infrastructure. This
+directory is created right next to the Docker Compose file and contains the
+following sub-directories:
 
 * `code/`: the Puppet code directory.
 * `puppet/`: Puppet configuration files, including `puppet/ssl/` containing
@@ -37,7 +38,7 @@ this directory and restarting the stack.
 * `puppetdb-postgres/`: the data files for the PostgreSQL instance used by
 PuppetDB
 * `serverdata/`: persistent data for Puppet Server
-* Note: On OSX, you must add the repository directory to "File Sharing" under
+* Note: On OSX, you must add the `persistence` directory to "File Sharing" under
   `Preferences>File Sharing` in order for these directories to be created
   and volume-mounted automatically. There is no need to add each sub directory.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ revoke the server's certificate and restart the stack with the changed
 `DNS_ALT_NAMES` value.
 
 When you first start the Puppet Infrastructure, the stack will create a
-`persistence/` directory with a number of sub-directories to store the
+`volumes/` directory with a number of sub-directories to store the
 persistent data that should survive the restart of your infrastructure. This
 directory is created right next to the Docker Compose file and contains the
 following sub-directories:
@@ -38,7 +38,7 @@ this directory and restarting the stack.
 * `puppetdb-postgres/`: the data files for the PostgreSQL instance used by
 PuppetDB
 * `serverdata/`: persistent data for Puppet Server
-* Note: On OSX, you must add the `persistence` directory to "File Sharing" under
+* Note: On OSX, you must add the `volumes` directory to "File Sharing" under
   `Preferences>File Sharing` in order for these directories to be created
   and volume-mounted automatically. There is no need to add each sub directory.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - DNS_ALT_NAMES
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
-      - ./code:/etc/puppetlabs/code/
-      - ./puppet:/etc/puppetlabs/puppet/
-      - ./serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - ./persistence/code:/etc/puppetlabs/code/
+      - ./persistence/puppet:/etc/puppetlabs/puppet/
+      - ./persistence/serverdata:/opt/puppetlabs/server/data/puppetserver/
 
   postgres:
     image: puppet/puppetdb-postgres
@@ -26,7 +26,7 @@ services:
     expose:
       - 5432
     volumes:
-      - ./puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ./persistence/puppetdb-postgres/data:/var/lib/postgresql/data/
 
   puppetdb:
     hostname: puppetdb
@@ -41,4 +41,4 @@ services:
       - postgres
       - puppet
     volumes:
-      - ./puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - ./persistence/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - DNS_ALT_NAMES
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
-      - ./persistence/code:/etc/puppetlabs/code/
-      - ./persistence/puppet:/etc/puppetlabs/puppet/
-      - ./persistence/serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - ./volumes/code:/etc/puppetlabs/code/
+      - ./volumes/puppet:/etc/puppetlabs/puppet/
+      - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
 
   postgres:
     image: puppet/puppetdb-postgres
@@ -26,7 +26,7 @@ services:
     expose:
       - 5432
     volumes:
-      - ./persistence/puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ./volumes/puppetdb-postgres/data:/var/lib/postgresql/data/
 
   puppetdb:
     hostname: puppetdb
@@ -41,4 +41,4 @@ services:
       - postgres
       - puppet
     volumes:
-      - ./persistence/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - ./volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/


### PR DESCRIPTION
Just to help keep things clean and separated, it's nice to have a root
home for this kind of thing to make it easy to rm-rf, gitignore,
reference, etc.