### PR TITLE
(maint) Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,45 @@
+pool:
+  # self-hosted agent on Windows 10 1709 environment
+  # includes newer Docker engine with LCOW enabled, new build of LCOW image
+  # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
+  name: Default
+
+steps:
+- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  clean: true  # whether to fetch clean each time
+- powershell: |
+    $line = '=' * 80
+    Write-Host "$line`nWindows`n$line`n"
+    Get-ComputerInfo |
+      select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer |
+      Out-String |
+      Write-Host
+    #
+    # Azure
+    #
+    Write-Host "`n`n$line`nAzure`n$line`n"
+    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+      ConvertTo-Json -Depth 10 |
+      Write-Host
+    #
+    # Docker
+    #
+    Write-Host "`n`n$line`nDocker`n$line`n"
+    docker version
+    docker images
+    docker info
+    sc.exe qc docker
+    #
+    # Ruby
+    #
+    Write-Host "`n`n$line`nRuby`n$line`n"
+    ruby --version
+    gem --version
+    bundle --version
+    #
+    # Environment
+    #
+    Write-Host "`n`n$line`nEnvironment`n$line`n"
+    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+  displayName: Diagnostic Host Information
+  name: hostinfo


### PR DESCRIPTION
- This will trigger branch authorization

- Azure Pipelines has a weird behavior that requires an azure-pipelines.yml to be in a repository before it will authorize a custom agent pool for use. Therefore this basic template needs to be merged first before the pipeline will go green.