### PR TITLE
(CPR-607) Update bin/puppet for cross-platform support

### DIFF
--- a/bin/puppet
+++ b/bin/puppet
@@ -1,5 +1,12 @@
-#! /bin/sh
+#! /usr/bin/env ruby
 
-cd "$(dirname "$0")/.." || exit 1
+status = 0
 
-docker-compose exec puppet puppet "$@"
+# want to run from one directory above where this file exists
+Dir.chdir(File.dirname(File.dirname(__FILE__))) do
+  output = %x(docker-compose exec puppet puppet #{ARGV.join(' ')})
+  puts output
+  status = $?
+end
+
+exit status.exitstatus

--- a/bin/puppet.ps1
+++ b/bin/puppet.ps1
@@ -1,9 +1,0 @@
-[CmdletBinding()]
-param (
-  [parameter(Mandatory=$False,Position=0,ValueFromRemainingArguments=$True)]
-  [Object[]] $Arguments
-)
-
-Push-Location (Join-Path -Path $PSScriptRoot -ChildPath '..') | Out-Null
-
-& docker-compose exec puppet puppet $Arguments


### PR DESCRIPTION
Rather than maintaining bin/puppet and bin/puppet.ps1, let's have a
cross-platform script that uses ruby and shells out to docker-compose.