### PR TITLE
Experiment with a special "migration" container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-code/
-puppet/
-puppetdb/
-puppetdb-postgres/
-serverdata/
+persistence/

--- a/Dockerfile.migration
+++ b/Dockerfile.migration
@@ -1,0 +1,3 @@
+FROM alpine:latest
+COPY migrate.sh /
+CMD /migrate.sh

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ revoke the server's certificate and restart the stack with the changed
 `DNS_ALT_NAMES` value.
 
 When you first start the Puppet Infrastructure, the stack will create a
-number of directories to store the persistent data that should survive the
-restart of your infrastructure. These directories are created right next to
-the Docker Compose file:
+`persistence/` directory with a number of sub-directories to store the
+persistent data that should survive the restart of your infrastructure. This
+directory is created right next to the Docker Compose file and contains the
+following sub-directories:
 
 * `code/`: the Puppet code directory.
 * `puppet/`: Puppet configuration files, including `puppet/ssl/` containing
@@ -37,7 +38,7 @@ this directory and restarting the stack.
 * `puppetdb-postgres/`: the data files for the PostgreSQL instance used by
 PuppetDB
 * `serverdata/`: persistent data for Puppet Server
-* Note: On OSX, you must add the repository directory to "File Sharing" under
+* Note: On OSX, you must add the `persistence` directory to "File Sharing" under
   `Preferences>File Sharing` in order for these directories to be created
   and volume-mounted automatically. There is no need to add each sub directory.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - DNS_ALT_NAMES
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
-      - ./code:/etc/puppetlabs/code/
-      - ./puppet:/etc/puppetlabs/puppet/
-      - ./serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - ./persistence/code:/etc/puppetlabs/code/
+      - ./persistence/puppet:/etc/puppetlabs/puppet/
+      - ./persistence/serverdata:/opt/puppetlabs/server/data/puppetserver/
 
   postgres:
     image: puppet/puppetdb-postgres
@@ -26,7 +26,7 @@ services:
     expose:
       - 5432
     volumes:
-      - ./puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ./persistence/puppetdb-postgres/data:/var/lib/postgresql/data/
 
   puppetdb:
     hostname: puppetdb
@@ -41,4 +41,4 @@ services:
       - postgres
       - puppet
     volumes:
-      - ./puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - ./persistence/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: '2'
 
 services:
+  migrate:
+    image: migrate:v3
+    volumes:
+      - ./:/pupperware/
+
   puppet:
     hostname: puppet
     image: puppet/puppetserver
@@ -14,9 +19,11 @@ services:
       - DNS_ALT_NAMES
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
-      - ./persistence/code:/etc/puppetlabs/code/
-      - ./persistence/puppet:/etc/puppetlabs/puppet/
-      - ./persistence/serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - ./volumes/code:/etc/puppetlabs/code/
+      - ./volumes/puppet:/etc/puppetlabs/puppet/
+      - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
+    depends_on:
+      - migrate
 
   postgres:
     image: puppet/puppetdb-postgres
@@ -26,7 +33,9 @@ services:
     expose:
       - 5432
     volumes:
-      - ./persistence/puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ./volumes/puppetdb-postgres/data:/var/lib/postgresql/data/
+    depends_on:
+      - migrate
 
   puppetdb:
     hostname: puppetdb
@@ -41,4 +50,6 @@ services:
       - postgres
       - puppet
     volumes:
-      - ./persistence/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - ./volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+    depends_on:
+      - migrate

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+# Migrates "./foo" to "./persistence/foo"
+function migrate_v1() {
+    local from="$1"
+    local to="persistence/$1"
+    if [ -d "$from" ]; then
+        if [ -d "$to" ]; then
+            echo "$to already exists; skipping"
+        else
+            echo "Moving $from to $to"
+            mv "$from" "$to"
+        fi
+    fi
+}
+
+# Migrates "./persistence/foo" to "./volumes/foo"
+function migrate_v2() {
+    local from="persistence/$1"
+    local to="volumes/$1"
+    if [ -d "$from" ]; then
+        if [ -d "$to" ]; then
+            echo "$to already exists; skipping"
+        else
+            echo "Moving $from to $to"
+            mv "$from" "$to"
+        fi
+    fi
+}
+
+# Moves top-level directories into persistence/*
+function migrate_v1_v2() {
+    echo "Migrating from v1 to v2 ..."
+    if [ ! -d ./persistence/ ]; then
+        echo "Creating persistence/ directory"
+        mkdir persistence
+    fi
+    migrate_v1 code
+    migrate_v1 puppet
+    migrate_v1 serverdata
+    migrate_v1 puppetdb
+    migrate_v1 puppetdb-postgres
+}
+
+# Moves persistence/* directories into volume/*
+function migrate_v2_v3() {
+    echo "Migrating from v2 to v3 ..."
+    if [ ! -d ./volumes/ ]; then
+        echo "Creating volumes/ directory"
+        mkdir volumes
+    fi
+    migrate_v2 code
+    migrate_v2 puppet
+    migrate_v2 serverdata
+    migrate_v2 puppetdb
+    migrate_v2 puppetdb-postgres
+    if [ -d ./persistence/ ]; then
+        echo "Renaming persistence/ directory to persistence_v1/"
+        echo "* The persistence_v1/ directory can now be manually removed"
+        mv persistence persistence_v1
+    fi
+}
+
+cd /pupperware/
+
+# Detect initial version: top-level directories
+# Migrate to v2 if necessary
+[ -d ./code ] && migrate_v1_v2
+
+# Detect v2: persistence/ directory
+# Migrate to v3 if necessary
+[ -d ./persistence/ ] && migrate_v2_v3
+
+echo "Migration finished"


### PR DESCRIPTION
This PR is just for discussion.

The goal is to figure out a pattern where we can run some code prior to
the production services starting up, which would allow us to perform
"migrations" from earlier versions of the compose file to the current
version. Essentially I'm after a "pre-up" phase that runs before the
normal "docker-compose up" phase.

This would be handy when we do things like move the location of
volume-mounted directories. The special migration container would detect
the old locations and move them into the new locations.

I'm not sure that we can reliably use "depends_on" and docker-compose
for this, because there's no guarantee that the migration container is
done running before the other containers start up. It currently works
because these are simple mv commands which happen to be fast enough.

The better solution is to bake in special "wait-for" support into each
production service/image.

----

```
nwolfe@natebook-pro:~/ws/puppet/pupperware$ make up
docker-compose up
WARNING: The DNS_ALT_NAMES variable is not set. Defaulting to a blank string.
Recreating pupperware_migrate_1 ... done
Recreating pupperware_puppetdb_1 ... done
Recreating pupperware_postgres_1 ... done
Recreating pupperware_puppet_1   ... done
Attaching to pupperware_migrate_1, pupperware_puppetdb_1, pupperware_postgres_1, pupperware_puppet_1
migrate_1   | Migrating from v1 to v2 ...
migrate_1   | Creating persistence/ directory
migrate_1   | Moving code to persistence/code
migrate_1   | Moving puppet to persistence/puppet
migrate_1   | Moving serverdata to persistence/serverdata
migrate_1   | Moving puppetdb to persistence/puppetdb
migrate_1   | Moving puppetdb-postgres to persistence/puppetdb-postgres
migrate_1   | Migrating from v2 to v3 ...
migrate_1   | Moving persistence/code to volumes/code
migrate_1   | Moving persistence/puppet to volumes/puppet
migrate_1   | Moving persistence/serverdata to volumes/serverdata
migrate_1   | Moving persistence/puppetdb to volumes/puppetdb
migrate_1   | Moving persistence/puppetdb-postgres to volumes/puppetdb-postgres
migrate_1   | Renaming persistence/ directory to persistence_v1/
migrate_1   | * The persistence_v1/ directory can now be manually removed
migrate_1   | Migration finished
pupperware_migrate_1 exited with code 0
postgres_1  | LOG:  database system was interrupted; last known up at 2018-10-22 21:29:28 UTC
postgres_1  | LOG:  database system was not properly shut down; automatic recovery in progress
postgres_1  | LOG:  invalid record length at 0/17749E0: wanted 24, got 0
postgres_1  | LOG:  redo is not required
postgres_1  | LOG:  MultiXact member wraparound protections are now enabled
postgres_1  | LOG:  database system is ready to accept connections
postgres_1  | LOG:  autovacuum launcher started
puppet_1    | 2018-10-22 21:32:06,718 INFO  [o.e.j.u.log] Logging initialized @20118ms to org.eclipse.jetty.util.log.Slf4jLog
puppet_1    | 2018-10-22 21:32:09,276 INFO  [p.t.s.w.jetty9-service] Initializing web server(s).
...
```