### PR TITLE
Make it possible to increase the number of compile containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+TOPDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+services: puppetserver puppetdb
+
+puppetserver:
+	@echo build local/puppetserver
+	@docker build -q -t local/puppetserver $(TOPDIR)/services/puppetserver
+
+puppetdb:
+	@echo build local/puppetdb
+	@docker build -q -t local/puppetdb $(TOPDIR)/services/puppetdb
+
+.PHONY: puppetserver puppetdb

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 TOPDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-services: puppetserver puppetdb
+services: lb puppetserver puppetdb
+
+lb:
+	@echo build local/lb
+	@docker build -q --network=host -t local/lb $(TOPDIR)/services/lb
 
 puppetserver:
 	@echo build local/puppetserver
@@ -10,4 +14,4 @@ puppetdb:
 	@echo build local/puppetdb
 	@docker build -q -t local/puppetdb $(TOPDIR)/services/puppetdb
 
-.PHONY: puppetserver puppetdb
+.PHONY: lb puppetserver puppetdb

--- a/bin/puppet
+++ b/bin/puppet
@@ -2,4 +2,4 @@
 
 cd "$(dirname "$0")/.." || exit 1
 
-docker-compose exec puppet puppet "$@"
+docker-compose exec master puppet "$@"

--- a/bin/puppet.ps1
+++ b/bin/puppet.ps1
@@ -6,4 +6,4 @@ param (
 
 Push-Location (Join-Path -Path $PSScriptRoot -ChildPath '..') | Out-Null
 
-& docker-compose exec puppet puppet $Arguments
+& docker-compose exec master puppet $Arguments

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   puppet:
     hostname: puppet
-    image: puppet/puppetserver
+    build: ./services/puppetserver
     ports:
       - 8140:8140
     environment:
@@ -36,7 +36,7 @@ services:
 
   puppetdb:
     hostname: puppetdb
-    image: puppet/puppetdb
+    build: ./services/puppetdb
     environment:
       - PUPPETDB_PASSWORD=puppetdb
       - PUPPETDB_USER=puppetdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,55 @@ services:
     volumes:
       - ./volumes/consul:/consul/data
 
+  # Logging from https://gist.github.com/codification/1733666f9ce9072b14906c4966c2abb5
+  rsyslog:
+    image: jumanjiman/rsyslog
+    volumes:
+      - rsyslog:/var/run/rsyslog/dev
+
   puppet:
-    hostname: puppet
-    build: ./services/puppetserver
+    build: ./services/lb
     ports:
       - 8140:8140
+      - 8765:8765
+      - 9000:9000
+    volumes:
+      # Needs certs/ca.pem, proxy_cert.pem, and crl.pem from puppet/ssl
+      # CRL means it needs to share a volume with master so that HAProxy
+      # sees updated CRL after a revocation
+      - ./volumes/puppet/ssl:/etc/ssl/
+      - rsyslog:/var/run/rsyslog/dev
+    depends_on:
+      - master  # the name 'master' must resolve before we can start the lb
+
+  master:
+    build: ./services/puppetserver
+    ports:
+      - 8140
     environment:
       # DNS_ALT_NAMES must be set before starting the stack the first time,
       # and must list all the names under which the puppetserver can be
       # reached. 'puppet' must be one of them, otherwise puppetdb won't be
       # able to get a cert. Add other names as a comma-separated list
       - DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}
+      - PUPPETSERVER_HOSTNAME
+      - PUPPETDB_SERVER_URLS=https://puppetdb:8081
+      - MAIN_PUPPET=yes
+    volumes:
+      - ./volumes/code:/etc/puppetlabs/code/
+      - ./volumes/puppet:/etc/puppetlabs/puppet/
+      - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
+
+  compiler:
+    # We do not want to start additional compilers by default; there
+    # does not seem a way to do this with docker-compose.
+    # See for example https://github.com/docker/compose/issues/1896
+    # You might think that using 'scale: 0' works, but that is just ignored
+    # and acts like 'scale: 1'
+    build: ./services/puppetserver
+    ports:
+      - 8140
+    environment:
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
       - ./volumes/code:/etc/puppetlabs/code/
@@ -62,3 +100,6 @@ services:
 
 networks:
   default:
+
+volumes:
+  rsyslog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: '3'
 
 services:
+  consul:
+    image: library/consul
+    ports:
+      - 8500 # Consul HTTP
+    environment:
+      - CONSUL_BIND_INTERFACE=eth0
+    volumes:
+      - ./volumes/consul:/consul/data
+
   puppet:
     hostname: puppet
     build: ./services/puppetserver

--- a/services/lb/Dockerfile
+++ b/services/lb/Dockerfile
@@ -1,0 +1,23 @@
+FROM haproxy:alpine
+
+ENV CONSUL_TEMPLATE_VERSION=0.19.5
+
+# HAProxy management port; not needed
+# EXPOSE 8765
+
+# Puppetserver
+EXPOSE 8140
+# Statistics page
+EXPOSE 9000
+
+RUN wget https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tgz \
+  && tar xfz consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tgz \
+  && mv consul-template /usr/bin/consul-template \
+  && rm consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tgz
+
+COPY haproxy.tpl /usr/local/etc/haproxy/haproxy.tpl
+COPY Dockerfile /
+COPY docker-entrypoint.sh /
+COPY haproxy.hcl /etc
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/services/lb/docker-entrypoint.sh
+++ b/services/lb/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# Master will cat public and private key into this file
+cert=/etc/ssl/proxy_cert.pem
+
+while [[ ! -f "$cert" ]]; do
+    sleep 1
+done
+
+exec consul-template -config=/etc/haproxy.hcl

--- a/services/lb/haproxy.hcl
+++ b/services/lb/haproxy.hcl
@@ -1,0 +1,14 @@
+consul {
+  address = "consul:8500"
+}
+
+template {
+  source = "/usr/local/etc/haproxy/haproxy.tpl"
+  destination = "/usr/local/etc/haproxy/haproxy.cfg"
+}
+
+exec {
+  command = "haproxy -W -f /usr/local/etc/haproxy/haproxy.cfg"
+  reload_signal = "SIGUSR2"
+  kill_signal = "SIGUSR1"
+}

--- a/services/lb/haproxy.tpl
+++ b/services/lb/haproxy.tpl
@@ -1,0 +1,50 @@
+# -*- conf -*-
+global
+  # admin socket, not needed
+  # stats socket ipv4@*:8765 level admin
+  tune.ssl.default-dh-param 2048
+  log /var/run/rsyslog/dev/log local0
+  log /var/run/rsyslog/dev/log local1
+  maxconn 50
+
+defaults
+  mode http
+  option httplog
+  timeout connect 5000
+  timeout check 5000
+  timeout client 30000
+  timeout server 30000
+
+listen stats # Define a listen section called "stats"
+  bind *:9000 # Listen on localhost:9000
+  stats enable  # Enable stats page
+  stats hide-version  # Hide HAProxy version
+  stats realm Haproxy\ Statistics  # Title text for popup window
+  stats uri /  # Stats URI
+  log global
+
+#---------------------------------------------------------------------
+# frontend with SSL termination
+# see https://github.com/vshn/puppet-in-docker/blob/master/haproxy/haproxy.tmpl
+#---------------------------------------------------------------------
+frontend puppet
+  bind *:8140 ssl ca-file /etc/ssl/certs/ca.pem crt /etc/ssl/proxy_cert.pem verify optional crl-file /etc/ssl/crl.pem
+  acl is_ca_uri path_beg "/puppet-ca/"
+  http-request set-header X-Client-Verify-Real  %[ssl_c_verify]
+  http-request set-header X-Client-Verify NONE if !{ hdr_val(X-Client-Verify-Real) eq 0 }
+  http-request set-header X-Client-Verify SUCCESS if { hdr_val(X-Client-Verify-Real) eq 0 }
+  http-request set-header X-Client-DN     CN=%{+Q}[ssl_c_s_dn(cn)]
+  http-request set-header X-Client-Cert   "-----BEGIN CERTIFICATE-----%%0A%[ssl_c_der,base64]%%0A-----END CERTIFICATE----- #" if { ssl_c_used }
+  use_backend ca if is_ca_uri
+  default_backend puppets
+  log global
+
+backend ca
+    server master "master:8140" check port 8140 inter 5s
+
+backend puppets
+    balance     roundrobin
+    server master master:8140 check port 8140 inter 5s
+    {{ range $i, $ip := ls "services/compiler" -}}
+      server compiler{{ add $i 1 }} {{ .Key }}:8140 check port 8140 inter 5s
+    {{ end -}}

--- a/services/puppetdb/Dockerfile
+++ b/services/puppetdb/Dockerfile
@@ -1,0 +1,4 @@
+# docker build -t local/puppetdb .
+FROM puppet/puppetdb
+
+COPY docker-entrypoint.sh /

--- a/services/puppetdb/docker-entrypoint.sh
+++ b/services/puppetdb/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
+if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ]; then
+  while ! nc -z "$PUPPETSERVER_HOSTNAME" 8140; do
+    sleep 1
+  done
+  set -e
+  /opt/puppetlabs/bin/puppet config set certname "$HOSTNAME"
+  /opt/puppetlabs/bin/puppet config set server "$PUPPETSERVER_HOSTNAME"
+  /opt/puppetlabs/bin/puppet agent --verbose --onetime --no-daemonize --waitforcert 120
+  /opt/puppetlabs/server/bin/puppetdb ssl-setup -f
+fi
+
+exec /opt/puppetlabs/server/bin/puppetdb "$@"

--- a/services/puppetdb/docker-entrypoint.sh
+++ b/services/puppetdb/docker-entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+master_running() {
+    test "$(curl -sfk https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple)" = running
+}
+
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
 if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ]; then
-  while ! nc -z "$PUPPETSERVER_HOSTNAME" 8140; do
+  while ! master_running; do
     sleep 1
   done
   set -e

--- a/services/puppetserver/Dockerfile
+++ b/services/puppetserver/Dockerfile
@@ -1,4 +1,12 @@
 # docker build -t local/puppetserver .
 FROM puppet/puppetserver
 
-COPY docker-entrypoint.sh /
+COPY docker-entrypoint.d /docker-entrypoint.d
+
+# We do not use https
+HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
+  curl --fail -H 'Accept: pson' \
+  --resolve 'puppet:8140:127.0.0.1' \
+  http://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
+  |  grep -q '"is_alive":true' \
+  || exit 1

--- a/services/puppetserver/Dockerfile
+++ b/services/puppetserver/Dockerfile
@@ -1,0 +1,4 @@
+# docker build -t local/puppetserver .
+FROM puppet/puppetserver
+
+COPY docker-entrypoint.sh /

--- a/services/puppetserver/docker-entrypoint.d/70-disable-https.sh
+++ b/services/puppetserver/docker-entrypoint.d/70-disable-https.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Change puppetserver settings to allow HTTP traffic since we terminate SSL
+# in haproxy
+# See https://puppet.com/docs/puppetserver/6.0/external_ssl_termination.html
+hocon() {
+    /opt/puppetlabs/puppet/lib/ruby/vendor_gems/bin/hocon "$@"
+}
+
+pushd /etc/puppetlabs/puppetserver/conf.d
+
+# Switch webserver to plain http
+hocon -f webserver.conf unset webserver.ssl-host
+hocon -f webserver.conf unset webserver.ssl-port
+hocon -f webserver.conf set webserver.host 0.0.0.0
+hocon -f webserver.conf set webserver.port 8140
+# Turn off legacy auth
+hocon -f puppetserver.conf set jruby-puppet.use-legacy-auth-conf false
+# Use HTTP headers for client auth
+hocon -f auth.conf set authorization.allow-header-cert-info true
+
+popd

--- a/services/puppetserver/docker-entrypoint.d/80-initialize-ca.sh
+++ b/services/puppetserver/docker-entrypoint.d/80-initialize-ca.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# HAProxy wants a .pem file that contains both our private and public SSL certs
+# To this end, initialize the CA explicitly and produce that file
+
+[[ -z "$MAIN_PUPPET" ]] && exit 0
+
+if [[ -z "${PUPPETSERVER_HOSTNAME}" ]]; then
+    # the default certname (fqdn) is absolutly useless in our situation
+    # we should either produce an error if PUPPETSERVER_HOSTNAME is not
+    # set or default to the Docker host name
+    echo "Please set PUPPETSERVER_HOSTNAME to the external name of the docker host"
+    exit 1
+fi
+
+cd /etc/puppetlabs/puppet/ssl
+
+CERTNAME="${PUPPETSERVER_HOSTNAME}"
+if [[ ! -f ca/ca_key.pem ]]; then
+    echo "initializing the CA"
+    puppetserver ca setup --ca-name "Pupperware on $CERTNAME" \
+                 --certname "$CERTNAME" --subject-alt-names "$DNS_ALT_NAMES"
+fi
+
+if [[ ! -s proxy_cert.pem ]]; then
+    echo "creating HAProxy cert"
+    # Create combined pem for HAProxy
+    touch proxy_cert.pem
+    chmod 0640 proxy_cert.pem
+    cat certs/"$CERTNAME".pem private_keys/"$CERTNAME".pem > proxy_cert.pem
+fi

--- a/services/puppetserver/docker-entrypoint.d/90-register-compiler.sh
+++ b/services/puppetserver/docker-entrypoint.d/90-register-compiler.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Additional compilers should not run a CA, but have to register themselves
+# with consul. When they are done, they need to remove themselves from
+# consul; this requires a bit of shell gymnastics since this script is run
+# as a separate command but needs to stick around to receive signals
+
+cleanup() {
+    echo "Unregistering $ip"
+    curl -X DELETE "http://consul:8500/v1/kv/services/compiler/$ip"
+}
+
+worker() {
+    trap cleanup EXIT
+    while true; do
+        sleep 86400
+    done
+}
+
+[[ -n "$MAIN_PUPPET" ]] && exit 0
+
+echo "turning off CA"
+cat > /etc/puppetlabs/puppetserver/services.d/ca.cfg <<EOF
+puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
+puppetlabs.trapperkeeper.services.watcher.filesystem-watch-service/filesystem-watch-service
+EOF
+
+ip=$(facter networking.ip)
+
+# Fork this script and have it wait for a signal; dumb-init makes sure
+# we'll get signals for the container forwarded to us
+worker &
+
+echo "Registering $ip"
+curl -X PUT --silent -o /dev/null --data up \
+     "http://consul:8500/v1/kv/services/compiler/$ip"


### PR DESCRIPTION
The big changes in this PR are

1. Put HAProxy in front of the Puppet master
1. Terminate SSL in HAProxy and switch the master(s) to accept HTTP requests
1. Change things so that `docker-compose up --scale compiler=N` can be used to scale the number of compilers up/down

This uses Consul behind the scenes for coordination.