### PR TITLE
(maint) Query Puppet URIs with Net::HTTP / Refactor test helpers / Switch to Compose v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   puppet:

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -7,14 +7,14 @@ describe 'The docker-compose file works' do
     @test_agent = "puppet_test#{Random.rand(1000)}"
     @mapped_ports = {}
     @timestamps = []
-    %x(docker-compose --help)
+    %x(docker-compose --no-ansi --help)
     if $? != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
   end
 
   after(:all) do
-    %x(docker-compose down)
+    %x(docker-compose --no-ansi down)
   end
 
   describe 'the cluster starts' do
@@ -27,10 +27,10 @@ describe 'The docker-compose file works' do
     end
 
     it 'should stop the cluster' do
-      ps = %x(docker-compose ps)
+      ps = %x(docker-compose --no-ansi ps)
       expect(ps.match('puppet')).not_to eq(nil)
-      %x(docker-compose down)
-      ps = %x(docker-compose ps)
+      %x(docker-compose --no-ansi down)
+      ps = %x(docker-compose --no-ansi ps)
       expect(ps.match('puppet')).to eq(nil)
     end
 

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -5,6 +5,7 @@ require "#{File.join(File.dirname(__FILE__), 'examples', 'running_cluster.rb')}"
 describe 'The docker-compose file works' do
   before(:all) do
     @test_agent = "puppet_test#{Random.rand(1000)}"
+    @mapped_ports = {}
     @timestamps = []
     %x(docker-compose --help)
     if $? != 0
@@ -21,6 +22,10 @@ describe 'The docker-compose file works' do
   end
 
   describe 'the cluster restarts' do
+    before(:all) do
+      @mapped_ports = {}
+    end
+
     it 'should stop the cluster' do
       ps = %x(docker-compose ps)
       expect(ps.match('puppet')).not_to eq(nil)

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -38,6 +38,7 @@ shared_examples 'a running pupperware cluster' do
       end
     end
   rescue Timeout::Error
+    STDOUT.puts('docker-compose never started a service named "puppet"')
     return ''
   else
     status = puppetserver_health_check(container)
@@ -79,8 +80,10 @@ shared_examples 'a running pupperware cluster' do
       end
     end
   rescue Timeout::Error
+    STDOUT.puts("failed to retrieve report for #{agent_name} due to timeout")
     return ''
   rescue
+    STDOUT.puts("failed to retrieve report for #{agent_name}: #{$!}")
     return ''
   end
 

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -9,11 +9,14 @@ shared_examples 'a running pupperware cluster' do
   end
 
   def get_service_base_uri(service, port)
-    service_ip_port = %x(docker-compose port #{service} #{port}).chomp
-    uri = URI("http://#{service_ip_port}")
-    uri.host = 'localhost' if uri.host == '0.0.0.0'
-    STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
-    return uri
+    @mapped_ports["#{service}:#{port}"] ||= begin
+      service_ip_port = %x(docker-compose port #{service} #{port}).chomp
+      uri = URI("http://#{service_ip_port}")
+      uri.host = 'localhost' if uri.host == '0.0.0.0'
+      STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
+      uri
+    end
+    @mapped_ports["#{service}:#{port}"]
   end
 
   def get_puppetdb_state

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -25,8 +25,7 @@ shared_examples 'a running pupperware cluster' do
     STDOUT.puts "retrieved raw puppetdb status: #{status}"
     return JSON.parse(status)['state'] unless status.empty?
   rescue
-    return ''
-  else
+    STDOUT.puts "Failure querying #{pdb_uri}: #{$!}"
     return ''
   end
 

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -9,11 +9,11 @@ shared_examples 'a running pupperware cluster' do
   end
 
   def get_service_container(service, timeout = 120)
-    container = %x(docker-compose ps --quiet #{service}).chomp
+    container = %x(docker-compose --no-ansi ps --quiet #{service}).chomp
     Timeout::timeout(timeout) do
       while container.empty?
         sleep(1)
-        container = %x(docker-compose ps --quiet #{service}).chomp
+        container = %x(docker-compose --no-ansi ps --quiet #{service}).chomp
       end
     end
 
@@ -26,7 +26,7 @@ shared_examples 'a running pupperware cluster' do
 
   def get_service_base_uri(service, port)
     @mapped_ports["#{service}:#{port}"] ||= begin
-      service_ip_port = %x(docker-compose port #{service} #{port}).chomp
+      service_ip_port = %x(docker-compose --no-ansi port #{service} #{port}).chomp
       uri = URI("http://#{service_ip_port}")
       uri.host = 'localhost' if uri.host == '0.0.0.0'
       STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
@@ -55,7 +55,7 @@ shared_examples 'a running pupperware cluster' do
     end
 
     # work around SERVER-2354
-    %x(docker-compose exec puppet puppet config set server puppet)
+    %x(docker-compose --no-ansi exec puppet puppet config set server puppet)
 
     return status
   end
@@ -67,7 +67,7 @@ shared_examples 'a running pupperware cluster' do
 
   def check_report(agent_name)
     pdb_uri = URI::join(get_service_base_uri('puppetdb', 8080), '/pdb/query/v4')
-    domain = %x(docker-compose exec -T puppet facter domain).chomp
+    domain = %x(docker-compose --no-ansi exec -T puppet facter domain).chomp
     body = "{ \"query\": \"nodes { certname = \\\"#{agent_name}.#{domain}\\\" } \" }"
 
     out = ''
@@ -94,8 +94,8 @@ shared_examples 'a running pupperware cluster' do
   end
 
   def clean_certificate(agent_name)
-    domain = %x(docker-compose exec -T puppet facter domain).chomp
-    %x(docker-compose exec -T puppet puppetserver ca clean --certname #{agent_name}.#{domain})
+    domain = %x(docker-compose --no-ansi exec -T puppet facter domain).chomp
+    %x(docker-compose --no-ansi exec -T puppet puppetserver ca clean --certname #{agent_name}.#{domain})
     return $?
   end
 
@@ -117,8 +117,8 @@ shared_examples 'a running pupperware cluster' do
   end
 
   it 'should start the cluster' do
-    %x(docker-compose up --detach)
-    ps = %x(docker-compose ps)
+    %x(docker-compose --no-ansi up --detach)
+    ps = %x(docker-compose --no-ansi ps)
     expect(ps.match('puppet')).not_to eq(nil)
   end
 

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -94,13 +94,14 @@ shared_examples 'a running pupperware cluster' do
     status = get_puppetdb_state
     # since pdb doesn't have a proper healthcheck yet, this could spin forever
     # add a timeout so it eventually returns.
-    Timeout::timeout(600) do
+    Timeout::timeout(240) do
       while status != 'running'
         sleep(1)
         status = get_puppetdb_state
       end
     end
   rescue Timeout::Error
+    STDOUT.puts('puppetdb never entered running state')
     return ''
   else
     return status

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -5,7 +5,9 @@ shared_examples 'a running pupperware cluster' do
   require 'net/http'
 
   def get_container_status(container)
-    %x(docker inspect "#{container}" --format '{{.State.Health.Status}}').chomp
+    status = %x(docker inspect "#{container}" --format '{{.State.Health.Status}}').chomp
+    STDOUT.puts "queried health status of #{container}: #{status}"
+    return status
   end
 
   def get_service_container(service, timeout = 120)
@@ -95,6 +97,7 @@ shared_examples 'a running pupperware cluster' do
 
   def clean_certificate(agent_name)
     domain = %x(docker-compose --no-ansi exec -T puppet facter domain).chomp
+    STDOUT.puts "cleaning cert for #{agent_name}.#{domain}"
     %x(docker-compose --no-ansi exec -T puppet puppetserver ca clean --certname #{agent_name}.#{domain})
     return $?
   end


### PR DESCRIPTION
 - Using containers to execute curl calls against each other is problematic.
   The shell calls don't translate to / work against Windows, and the %x calls
   eat stderr, which make debugging failures difficult.

 - Instead, find the mapped localhost ports and use Ruby Net::HTTP to query
   endpoints directly (and cache the lookups)

 - Instead of a specific get_puppetdb_base_uri, refactor to a method called
   get_service_base_uri that takes a service name and port

 - When HTTP requests fail, log some info for puppetdb check

 - The slowest platform, Windows, has PDB start responding within 2 minutes
   when it works properly.
   There is no need to wait 10 minutes for "starting". It's better to let CI runs die quickly.

 - Add diag messages during rescues

 - The test method start_puppetserver was doing a lot of varied work. Simplify
   it by extracting a helper method to find container ids for specific services

 - Also rename puppetserver_health_check to get_container_status as the method
   was already very generic and its naming should better reflect that.

 - Remove colorized output from CI runs
 - Azure Pipelines doesn't support color codes and the output looks
   terrible
 - Emit some additional progress information so that it can be easier
   to determine where / why test runs failed
 - Switch to Compose v3
   - Windows compose needs at least 2.1 due to API version
   - Load-balancing work needs at least 2.2
   - Swarm compatibility for features we intend to implement requires 3
