### PR TITLE
Add a shim for the puppetserver CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ default. In a similar manner, any other task that you would perform on a
 puppet master by running `puppet x y z ...` can be achieved against the
 stack by running `./bin/puppet x y z ...`.
 
+There is also a similar script providing easy access to `puppetserver` commands. This is particularly
+useful for CA and cert management via the `ca` subcommand.
+
 ### Changing postgresql password
 
 The postgresql instance uses password authentication for communication with the

--- a/bin/puppetserver
+++ b/bin/puppetserver
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+cd "$(dirname "$0")/.." || exit 1
+
+docker-compose exec puppet puppetserver "$@"

--- a/bin/puppetserver.ps1
+++ b/bin/puppetserver.ps1
@@ -1,0 +1,9 @@
+[CmdletBinding()]
+param (
+  [parameter(Mandatory=$False,Position=0,ValueFromRemainingArguments=$True)]
+  [Object[]] $Arguments
+)
+
+Push-Location (Join-Path -Path $PSScriptRoot -ChildPath '..') | Out-Null
+
+& docker-compose exec puppet puppetserver $Arguments


### PR DESCRIPTION
We currently have a shim wrapping the puppet command, to make it easier
to use from outside the container. This commit adds a similar shim for
the puppetserver CLI, which is primarily important for the `ca`
subcommand, to facilitate cert management.