### PR TITLE
(CPR-646) Use official Postgres container on Linux

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: puppet/puppetdb-postgres
+    image: postgres:9.6
     volumes:
       - ./volumes/puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ./postgres-custom:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Builds on #27 

- Instead of using the puppet/puppetdb-postgres image, use the official
  Postgres image, pinned to 9.6

  That image can be customized through /docker-entrypoint-initdb.d just like
  the Windows container can be customized with c:\docker-entrypoint-initdb.d

  Use the existing extensions.sql script that enables the 2 Postgres
  extensions that PuppetDB requires