### PR TITLE
(MAINT) SSL certs without Ruby, Puppet

### DIFF
--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+#
+# Get a signed certificate for this host.
+#
+# Uses OpenSSL and curl directly to generate a new CSR and get it signed by the
+# Puppet Server CA. Does not support custom CSR extensions at the moment.
+#
+# Intended to be used in place of a full-blown puppet agent run that is solely
+# for getting SSL certificates onto the host.
+#
+# Files will be placed in the same default directory location and structure
+# that the puppet agent would put them, which is /etc/puppetlabs/puppet/ssl.
+#
+# Fails under the following conditions:
+# - CA host cannot be reached
+# - CA already has signed certificate for this host
+# - SSL files already exist on this host
+#
+# Arguments:
+#   $1  (Optional) Certname to use, defaults to $HOSTNAME
+#
+# Optional environment variables:
+#   WAITFORCERT            Number of seconds to wait for certificate to be
+#                          signed, defaults to 120
+#   PUPPETSERVER_HOSTNAME  Hostname of Puppet Server CA, defaults to "puppet"
+#   SSLDIR                 Root directory to write files to, defaults to
+#                          "/etc/puppetlabs/puppet/ssl"
+
+msg() {
+    echo "($0) $1"
+}
+
+error() {
+    msg "Error: $1"
+    exit 1
+}
+
+### Verify dependencies available
+! type -p openssl > /dev/null && error "openssl not found on PATH"
+! type -p curl > /dev/null && error "curl not found on PATH"
+
+### Verify options are valid
+CERTNAME="${1:-${HOSTNAME}}"
+[ -z "${CERTNAME}" ] && error "certificate name must be non-empty value"
+PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
+SSLDIR="${SSLDIR:-/etc/puppetlabs/puppet/ssl}"
+WAITFORCERT=${WAITFORCERT:-120}
+
+### Create directories and files
+PUBKEYDIR="${SSLDIR}/public_keys"
+PRIVKEYDIR="${SSLDIR}/private_keys"
+CSRDIR="${SSLDIR}/certificate_requests"
+CERTDIR="${SSLDIR}/certs"
+mkdir -p "${SSLDIR}" "${PUBKEYDIR}" "${PRIVKEYDIR}" "${CSRDIR}" "${CERTDIR}"
+PUBKEYFILE="${PUBKEYDIR}/${CERTNAME}.pem"
+PRIVKEYFILE="${PRIVKEYDIR}/${CERTNAME}.pem"
+CSRFILE="${CSRDIR}/${CERTNAME}.pem"
+CERTFILE="${CERTDIR}/${CERTNAME}.pem"
+CACERTFILE="${CERTDIR}/ca.pem"
+
+CA="https://${PUPPETSERVER_HOSTNAME}:8140/puppet-ca/v1"
+CERTSUBJECT="/CN=${CERTNAME}"
+CERTHEADER="-----BEGIN CERTIFICATE-----"
+CURLFLAGS="--silent --show-error --cacert ${CACERTFILE}"
+
+### Print configuration for troubleshooting
+msg "Getting signed certificate for '${CERTNAME}' (${CERTSUBJECT})"
+msg "Using Puppet CA at '${CA}'"
+msg "Saving SSL files in '${SSLDIR}'"
+msg "Waiting up to ${WAITFORCERT} seconds for certificate to be signed"
+
+### Get the CA certificate for use with subsequent requests
+### Fail-fast if curl errors or the CA certificate can't be parsed
+curl --insecure --silent --show-error --output "${CACERTFILE}" "${CA}/certificate/ca"
+if [ $? -ne 0 ]; then
+    error "cannot reach CA host '${PUPPETSERVER_HOSTNAME}'"
+elif ! openssl x509 -subject -issuer -noout -in "${CACERTFILE}"; then
+    error "invalid CA certificate"
+fi
+
+### Check the CA does not already have a signed certificate for this host
+output="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
+if [ "$(echo "${output}" | head -1)" = "${CERTHEADER}" ]; then
+    error "CA already has signed certificate for '${CERTNAME}'"
+fi
+
+### Generate keys and CSR for this host
+[ -s "${PRIVKEYFILE}" ] && error "private key '${PRIVKEYFILE}' already exists"
+[ -s "${PUBKEYFILE}" ] && error "public key '${PUBKEYFILE}' already exists"
+[ -s "${CSRFILE}" ] && error "certificate request '${CSRFILE}' already exists"
+openssl genrsa -out "${PRIVKEYFILE}" 4096
+openssl rsa -in "${PRIVKEYFILE}" -pubout -out "${PUBKEYFILE}"
+openssl req -new -key "${PRIVKEYFILE}" -out "${CSRFILE}" -subj "${CERTSUBJECT}"
+
+### Submit CSR
+curl ${CURLFLAGS} -X PUT -H "Content-Type: text/plain" \
+    --data-binary "@${CSRFILE}" "${CA}/certificate_request/${CERTNAME}"
+
+### Retrieve signed certificate; wait and try again with a timeout
+sleeptime=10
+timewaited=0
+cert="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
+while [ "$(echo "${cert}" | head -1)" != "${CERTHEADER}" ]; do
+    [ ${timewaited} -ge ${WAITFORCERT} ] && \
+        error "timed-out waiting for certificate to be signed"
+    msg "Waiting for certificate to be signed..."
+    sleep ${sleeptime}
+    timewaited=$((${timewaited}+${sleeptime}))
+    cert="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
+done
+echo "${cert}" > "${CERTFILE}"
+
+### Verify we got a signed certificate
+if [ -f "${CERTFILE}" ] && [ "$(head -1 "${CERTFILE}")" = "${CERTHEADER}" ]; then
+    if openssl x509 -subject -issuer -noout -in "${CERTFILE}"; then
+        msg "Successfully signed certificate '${CERTFILE}'"
+    else
+        error "invalid signed certificate '${CERTFILE}'"
+    fi
+else
+    error "failed to get signed certificate for '${CERTNAME}'"
+fi


### PR DESCRIPTION
The intention is to remove the need for Ruby and Puppet in order to get
SSL certs.

This simplifies the requirements for "dockerizing" an application since
openssl and curl are available in many places that ruby and the
puppet-agent aren't.

This script should be downloaded via "ADD \<url\>" in any Dockerfile,
and then executed in the application entrypoint script.

----

Defaults and overrides:
* Uses the Puppet Server CA at hostname `puppet` (override via `PUPPETSERVER_HOSTNAME=foo /ssl.sh`)
* Generates certificate for subject `$HOSTNAME` (override via script argument: `/ssl.sh puppetdb`)
* Waits 120 seconds for CSR to be signed (override via `WAITFORCERT=60 /ssl.sh`)
* Saves files under same place agent does: /etc/puppetlabs/puppet/ssl (override via `SSLDIR=/foo /ssl.sh`)
  * Builds out same directory structure tree so existing tools still work, like the PuppetDB ssl-setup script

----

For example, this is what it looks like to ADD this script from this PR branch, at this SHA:
```
ADD https://raw.githubusercontent.com/puppetlabs/pupperware/0020a7a4046431e27f60a93f5daf97829415b2a9/shared/ssl.sh /ssl.sh
```

----

Example output (with autosign=true so no WAITFORCERT output):
```
(/ssl.sh) Getting signed certificate for 'af2b0864a201'
(/ssl.sh) Using Puppet CA at 'https://puppet:8140/puppet-ca/v1'
(/ssl.sh) Saving SSL files in '/etc/puppetlabs/puppet/ssl'
(/ssl.sh) Waiting up to 120 seconds for certificate to be signed
Generating RSA private key, 4096 bit long modulus
...............++++
..............................................++++
e is 65537 (0x10001)
writing RSA key
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1931  100  1931    0     0  32183      0 --:--:-- --:--:-- --:--:-- 32183
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1915  100  1915    0     0  34196      0 --:--:-- --:--:-- --:--:-- 34196
(/ssl.sh) Successfully signed certificate '/etc/puppetlabs/puppet/ssl/certs/af2b0864a201.pem'
```