### PR TITLE
(maint) Update Docker versions in README / fix docker-compose.yaml for 1.24.0-rc1

### DIFF
--- a/README-windows.md
+++ b/README-windows.md
@@ -197,14 +197,14 @@ Alternatively, it may be simpler to do this on OSX with the help of Homebrew, as
 
 To provision the compose files in this repository also requires a working `docker-compose.exe`. Windows nightly builds are not available ([issue 6308 filed](https://github.com/docker/compose/issues/6308)), but reasonably release builds are available at the [docker-compose GitHub releases page](https://github.com/docker/compose/releases/). Run the following PowerShell script to:
 
-* Download the 1.23.1 build of docker-compose
+* Download the 1.24.0-rc1 build of docker-compose
 * Install it to expected location
 
 ```powershell
-# download docker-compose 1.23.1 from November 1. 2018
+# download docker-compose 1.24.0-rc1 from Jan 14 2019
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-Invoke-WebRequest -OutFile "${ENV:ProgramFiles}\docker\docker-compose.exe" https://github.com/docker/compose/releases/download/1.23.1/docker-compose-Windows-x86_64.exe
+Invoke-WebRequest -OutFile "${ENV:ProgramFiles}\docker\docker-compose.exe" https://github.com/docker/compose/releases/download/1.24.0-rc1/docker-compose-Windows-x86_64.exe
 ```
 
 ### Build the docker-compose binaries (Alternate Build Workflow)
@@ -289,10 +289,10 @@ Docker-compose should also provide information like:
 ```
 PS> docker-compose version
 
-docker-compose version 1.23.0dev, build de8717cd
-docker-py version: 3.5.0
-CPython version: 3.6.7
-OpenSSL version: OpenSSL 1.0.2p  14 Aug 2018
+docker-compose version 1.24.0-rc1, build 0f3d4dda
+docker-py version: 3.7.0
+CPython version: 3.6.6
+OpenSSL version: OpenSSL 1.0.2o  27 Mar 2018
 ```
 
 With all of the LCOW setup verified, it should now be possible to launch side-by-side

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ To get started, you will need an installation of
 [Docker Compose](https://docs.docker.com/compose/install/) on the host on
 which you will run your Puppet Infrastructure.
 
+## Required versions
+
+* Docker Compose - must support `version: '3'` of the compose file format, which requires Docker Engine `1.13.0+`. [Full compatibility matrix](https://docs.docker.com/compose/compose-file/compose-versioning/)
+  * Linux is tested with docker-compose `1.22`
+  * Windows is tested with `docker-compose version 1.24.0-rc1, build 0f3d4dda`
+  * OSX is tested with `docker-compose version 1.23.2, build 1110ad01`
+* Docker Engine support is only tested on versions newer than `17.09.0-ce`
+  * Linux is tested with (client and server) `17.09.0-ce` using API version `1.32` (`Git commit:   afdb6d4`)
+  * Windows is tested with newer nightly versions that enable LCOW support / fix bugs in the Docker runtime (minimum required is edge release `18.02`, but latest highly recommended)
+      - Client `master-dockerproject-2019-01-08` using API version `1.40` (`Git commit:        d04b6165`)
+      - Server `master-dockerproject-2019-01-08` using API version `1.40 (minimum version 1.24)` (`Git commit:        77df18c`) with `Experimental: true`
+  * OSX is tested during development with `Docker Engine - Community` edition
+      - Client `18.09.1` using API version `1.39` (`Git commit:        4c52b90`)
+      - Server `18.09.1` using API version `1.39 (minimum version 1.12)` (`Git commit:       4c52b90`)
+
+## Provisioning
+
 Once you have Docker Compose installed, you can start the stack on Linux with:
 ```
     DNS_ALT_NAMES=host.example.com docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       - ./volumes/code:/etc/puppetlabs/code/
       - ./volumes/puppet:/etc/puppetlabs/puppet/
       - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
-    networks:
-      default:
 
   postgres:
     environment:
@@ -31,8 +29,6 @@ services:
     # so define them in .override.yml and .windows.yml since target varies
     # either /var/lib/postgresql/data/ on Linux or c:\data on Windows
     # https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
-    networks:
-      default:
 
   puppetdb:
     hostname: puppetdb
@@ -48,8 +44,6 @@ services:
       - puppet
     volumes:
       - ./volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
-    networks:
-      default:
 
 networks:
   default:


### PR DESCRIPTION
- docker-compose 1.24.0 seems to have difficulty in merging
   YAML for the `networks` key

   A solution is removing the declaration from each of the service
   declarations like this

		networks:
		  default:

   Instead, relying on the global default is sufficient without
   having explicit `networks` per service.

   This was initially setup in 2549f19
   to support an Azure specific override necessary for accessing
   endpoints on the master.

   It may be possible to later refactor this out, but not at this time.

- Update Docker versions in README