### PR TITLE
(MAINT) Use `command -v` instead of `type -p`

### DIFF
--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -36,8 +36,8 @@ error() {
 }
 
 ### Verify dependencies available
-! type -p openssl > /dev/null && error "openssl not found on PATH"
-! type -p curl > /dev/null && error "curl not found on PATH"
+! command -v openssl > /dev/null && error "openssl not found on PATH"
+! command -v curl > /dev/null && error "curl not found on PATH"
 
 ### Verify options are valid
 CERTNAME="${1:-${HOSTNAME}}"


### PR DESCRIPTION
The `-p` flag doesn't exist on Ubuntu, and we don't want to have
OS-specific behavior in the SSL script, so use a method that exists on
all platforms (or at least Alpine, Ubuntu, Debian, Centos).