### PR TITLE
(maint) Produce more CI output

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --format RspecJunitFormatter
 --out TEST-rspec.xml
 --format documentation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,17 @@ steps:
     #
     # Azure
     #
-    Write-Host "`n`n$line`nAzure`n$line`n"
-    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
-      ConvertTo-Json -Depth 10 |
-      Write-Host
+    $assetTag = Get-WmiObject -class Win32_SystemEnclosure -namespace root\CIMV2 |
+      Select -ExpandProperty SMBIOSAssetTag
+
+    # only Azure VMs have this hard-coded DMI value
+    if ($assetTag -eq '7783-7084-3265-9085-8269-3286-77')
+    {
+      Write-Host "`n`n$line`nAzure`n$line`n"
+      Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+        ConvertTo-Json -Depth 10 |
+        Write-Host
+    }
     #
     # Docker
     #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ steps:
     Write-Host "`n`n$line`nRuby`n$line`n"
     ruby --version
     gem --version
+    gem env
     bundle --version
     #
     # Environment
@@ -74,6 +75,7 @@ steps:
     [System.IO.File]::WriteAllLines(".env", $content, $Utf8NoBomEncoding)
     Get-Content -Path '.env'
     Write-Host 'Executing Pupperware specs'
+    bundle exec rspec --version
     bundle exec rspec spec --fail-fast
   displayName: Test pupperware
   name: test_pupperware

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -9,7 +9,7 @@ describe 'The docker-compose file works' do
     @test_agent = "puppet_test#{Random.rand(1000)}"
     @mapped_ports = {}
     @timestamps = []
-    status = run_command('docker-compose --no-ansi --help')
+    status = run_command('docker-compose --no-ansi --help')[:status]
     if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
@@ -17,7 +17,8 @@ describe 'The docker-compose file works' do
 
   after(:all) do
     STDOUT.puts("Tearing down test cluster")
-    ids = %x(docker-compose --no-ansi --log-level INFO ps -q).chomp
+    result = run_command('docker-compose --no-ansi --log-level INFO ps -q')
+    ids = result[:stdout].chomp
     STDOUT.puts("Retrieved running container ids:\n#{ids}")
     ids.each_line do |id|
       STDOUT.puts("Killing container #{id}")
@@ -39,10 +40,10 @@ describe 'The docker-compose file works' do
     # don't run this on Windows because compose down takes forever
     # https://github.com/docker/for-win/issues/629
     it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
-      ps = %x(docker-compose --no-ansi ps)
+      ps = run_command('docker-compose --no-ansi ps')[:stdout].chomp
       expect(ps.match('puppet')).not_to eq(nil)
       run_command('docker-compose --no-ansi down')
-      ps = %x(docker-compose --no-ansi ps)
+      ps = run_command('docker-compose --no-ansi ps')[:stdout].chomp
       expect(ps.match('puppet')).to eq(nil)
     end
 

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -3,12 +3,14 @@
 require "#{File.join(File.dirname(__FILE__), 'examples', 'running_cluster.rb')}"
 
 describe 'The docker-compose file works' do
+  include Helpers
+
   before(:all) do
     @test_agent = "puppet_test#{Random.rand(1000)}"
     @mapped_ports = {}
     @timestamps = []
-    %x(docker-compose --no-ansi --help)
-    if $? != 0
+    status = run_command('docker-compose --no-ansi --help')
+    if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
   end
@@ -19,10 +21,10 @@ describe 'The docker-compose file works' do
     STDOUT.puts("Retrieved running container ids:\n#{ids}")
     ids.each_line do |id|
       STDOUT.puts("Killing container #{id}")
-      %x(docker container kill #{id})
+      run_command("docker container kill #{id}")
     end
     # still needed to remove network / provide failsafe
-    %x(docker-compose --no-ansi down)
+    run_command('docker-compose --no-ansi down')
   end
 
   describe 'the cluster starts' do
@@ -39,7 +41,7 @@ describe 'The docker-compose file works' do
     it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
       ps = %x(docker-compose --no-ansi ps)
       expect(ps.match('puppet')).not_to eq(nil)
-      %x(docker-compose --no-ansi down)
+      run_command('docker-compose --no-ansi down')
       ps = %x(docker-compose --no-ansi ps)
       expect(ps.match('puppet')).to eq(nil)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'open3'
+
+module Helpers
+  def run_command(command)
+    status = nil
+    STDOUT.puts "Executing #{command}"
+    Open3.popen2e(command) do |stdin, stdout_stderr, wait_thread|
+      Thread.new do
+        stdout_stderr.each { |l| STDOUT.puts l }
+      end
+
+      stdin.close
+      status = wait_thread.value
+    end
+
+    status
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,17 +2,21 @@ require 'open3'
 
 module Helpers
   def run_command(command)
+    stdout_string = ''
     status = nil
-    STDOUT.puts "Executing #{command}"
-    Open3.popen2e(command) do |stdin, stdout_stderr, wait_thread|
+
+    Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
       Thread.new do
-        stdout_stderr.each { |l| STDOUT.puts l }
+        stdout.each { |l| stdout_string << l; STDOUT.puts l }
+      end
+      Thread.new do
+        stderr.each { |l| STDOUT.puts l }
       end
 
       stdin.close
       status = wait_thread.value
     end
 
-    status
+    { status: status, stdout: stdout_string }
   end
 end


### PR DESCRIPTION
Bring in sync with updates to other repos. Retrieve more output from stdout / stderr.

Diff of Travis log, demonstrating how much more we now get for the `%x` to `popen` change (similar improvements in Azure)

```diff
--- from_file
+++ Travis NEW
@@ -1,97 +1,217 @@
-Travis OLD
+Travis NEW
 
 $ bundle exec rspec spec --fail-fast
 The docker-compose file works

+Define and run multi-container applications with Docker.
+Usage:
+  docker-compose [-f <arg>...] [options] [COMMAND] [ARGS...]
+  docker-compose -h|--help
+Options:
+  -f, --file FILE             Specify an alternate compose file
+                              (default: docker-compose.yml)
+  -p, --project-name NAME     Specify an alternate project name
+                              (default: directory name)
+  --verbose                   Show more output
+  --log-level LEVEL           Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+  --no-ansi                   Do not print ANSI control characters
+  -v, --version               Print version and exit
+  -H, --host HOST             Daemon socket to connect to
+  --tls                       Use TLS; implied by --tlsverify
+  --tlscacert CA_PATH         Trust certs signed only by this CA
+  --tlscert CLIENT_CERT_PATH  Path to TLS certificate file
+  --tlskey TLS_KEY_PATH       Path to TLS key file
+  --tlsverify                 Use TLS and verify the remote
+  --skip-hostname-check       Don't check the daemon's hostname against the
+                              name specified in the client certificate
+  --project-directory PATH    Specify an alternate working directory
+                              (default: the path of the Compose file)
+  --compatibility             If set, Compose will attempt to convert deploy
+                              keys in v3 files to their non-Swarm equivalent
+Commands:
+  build              Build or rebuild services
+  bundle             Generate a Docker bundle from the Compose file
+  config             Validate and view the Compose file
+  create             Create services
+  down               Stop and remove containers, networks, images, and volumes
+  events             Receive real time events from containers
+  exec               Execute a command in a running container
+  help               Get help on a command
+  images             List images
+  kill               Kill containers
+  logs               View output from containers
+  pause              Pause services
+  port               Print the public port for a port binding
+  ps                 List containers
+  pull               Pull service images
+  push               Push service images
+  restart            Restart services
+  rm                 Remove stopped containers
+  run                Run a one-off command
+  scale              Set number of containers for a service
+  start              Start services
+  stop               Stop services
+  top                Display the running processes
+  unpause            Unpause services
+  up                 Create and start containers
+  version            Show the Docker-Compose version information

   the cluster starts

+latest: Pulling from puppet/puppetserver
+Digest: sha256:420078b4885a9cba6b58c5994e9245b8785755e0f816ca1c509755261915eb13
+Status: Downloaded newer image for puppet/puppetserver:latest
+9.6: Pulling from library/postgres
+Digest: sha256:85b4afcbfd2ef826bb6a2c60e1270399d599cc609c3b3961c992995293f8abd1
+Status: Downloaded newer image for postgres:9.6
+latest: Pulling from puppet/puppetdb
+Digest: sha256:b680ead27ae3e5b6fbef32f16c0ba686c982f07b7a838aacc1a575d25e2590b0
+Status: Downloaded newer image for puppet/puppetdb:latest

+       Name                      Command                       State                   Ports         
+-----------------------------------------------------------------------------------------------------
+pupperware_puppet_1   dumb-init /docker-entrypoi ...   Up (health: starting)   0.0.0.0:8140->8140/tcp
+        Name                       Command                       State                                Ports                      
+---------------------------------------------------------------------------------------------------------------------------------
+pupperware_puppetdb_1   /sbin/tini -g -- /docker-e ...   Up (health: starting)   0.0.0.0:32769->8080/tcp, 0.0.0.0:32768->8081/tcp
+        Name                       Command              State    Ports  
+------------------------------------------------------------------------
+pupperware_postgres_1   docker-entrypoint.sh postgres   Up      5432/tcp

     should start all of the cluster services

+puppet

 service named 'puppet' is hosted in container: 'puppet'

+starting
+the input device is not a TTY

     should start puppetserver

+0.0.0.0:32769
+ extname  | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition 
+----------+----------+--------------+----------------+------------+-----------+--------------
+ plpgsql  |       10 |           11 | f              | 1.0        |           | 
+ pg_trgm  |       10 |         2200 | t              | 1.3        |           | 
+ pgcrypto |       10 |         2200 | t              | 1.3        |           | 
+(3 rows)

 Status: Downloaded newer image for puppet/puppet-agent-alpine:latest
+Info: Creating a new SSL key for puppet_test986.c.eco-emissary-99515.internal
+Info: Downloaded certificate for ca from puppet
+Info: Downloaded certificate revocation list for ca from puppet
+Info: csr_attributes file loading from /etc/puppetlabs/puppet/csr_attributes.yaml
+Info: Creating a new SSL certificate request for puppet_test986.c.eco-emissary-99515.internal
+Info: Certificate Request fingerprint (SHA256): 5D:E2:B2:F3:18:05:B8:02:03:2A:67:E1:6F:A8:41:AB:C6:EC:86:C2:6E:B4:C0:5F:A5:63:5C:36:FD:D2:41:A7
+Info: Downloaded certificate for puppet_test986.c.eco-emissary-99515.internal from puppet
+Info: Using configured environment 'production'
+Info: Retrieving pluginfacts
+Info: Retrieving plugin
+Info: Retrieving locales
+Info: Caching catalog for puppet_test986.c.eco-emissary-99515.internal
+Info: Applying configuration version '1552080681'
+Info: Creating state file /opt/puppetlabs/puppet/cache/state/state.yaml
+Notice: Applied catalog in 0.02 seconds
+Changes:
+Events:
+Resources:
+            Total: 7
+Time:
+       Filebucket: 0.00
+         Schedule: 0.00
+   Transaction evaluation: 0.02
+   Catalog application: 0.02
+   Convert catalog: 0.10
+   Fact generation: 0.20
+      Plugin sync: 0.34
+   Node retrieval: 0.78
+   Config retrieval: 1.55
+         Last run: 1552080682
+            Total: 3.01
+Version:
+           Config: 1552080681
+           Puppet: 6.3.1

     should be able to run an agent

+c.eco-emissary-99515.internal

     should have a report in puppetdb

+c.eco-emissary-99515.internal
+Revoked certificate for puppet_test986.c.eco-emissary-99515.internal
+Cleaned files related to puppet_test986.c.eco-emissary-99515.internal

     should be able to clean a certificate

   the cluster restarts
+        Name                       Command                  State                            Ports                      
+------------------------------------------------------------------------------------------------------------------------
+pupperware_postgres_1   docker-entrypoint.sh postgres    Up             5432/tcp                                        
+pupperware_puppet_1     dumb-init /docker-entrypoi ...   Up (healthy)   0.0.0.0:8140->8140/tcp                          
+pupperware_puppetdb_1   /sbin/tini -g -- /docker-e ...   Up (healthy)   0.0.0.0:32769->8080/tcp, 0.0.0.0:32768->8081/tcp

+Name   Command   State   Ports
+------------------------------

+       Name                      Command                       State                   Ports         
+-----------------------------------------------------------------------------------------------------
+pupperware_puppet_1   dumb-init /docker-entrypoi ...   Up (health: starting)   0.0.0.0:8140->8140/tcp
+        Name                       Command                       State                                Ports                      
+---------------------------------------------------------------------------------------------------------------------------------
+pupperware_puppetdb_1   /sbin/tini -g -- /docker-e ...   Up (health: starting)   0.0.0.0:32771->8080/tcp, 0.0.0.0:32770->8081/tcp
+        Name                       Command              State    Ports  
+------------------------------------------------------------------------
+pupperware_postgres_1   docker-entrypoint.sh postgres   Up      5432/tcp
     should start all of the cluster services


+puppet
 service named 'puppet' is hosted in container: 'puppet'
+starting
+the input device is not a TTY

     should start puppetserver
+0.0.0.0:32771

+ extname  | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition 
+----------+----------+--------------+----------------+------------+-----------+--------------
+ plpgsql  |       10 |           11 | f              | 1.0        |           | 
+ pg_trgm  |       10 |         2200 | t              | 1.3        |           | 
+ pgcrypto |       10 |         2200 | t              | 1.3        |           | 
+(3 rows)

     should include postgres extensions

+Info: Creating a new SSL key for puppet_test986.c.eco-emissary-99515.internal
+Info: Downloaded certificate for ca from puppet
+Info: Downloaded certificate revocation list for ca from puppet
+Info: csr_attributes file loading from /etc/puppetlabs/puppet/csr_attributes.yaml
+Info: Creating a new SSL certificate request for puppet_test986.c.eco-emissary-99515.internal
+Info: Certificate Request fingerprint (SHA256): 9F:57:03:91:68:C6:4B:E1:42:3F:F1:0E:3D:C0:D2:50:01:7D:5C:0D:63:CC:99:29:2D:76:A8:00:D0:70:42:68
+Info: Downloaded certificate for puppet_test986.c.eco-emissary-99515.internal from puppet
+Info: Using configured environment 'production'
+Info: Retrieving pluginfacts
+Info: Retrieving plugin
+Info: Retrieving locales
+Info: Caching catalog for puppet_test986.c.eco-emissary-99515.internal
+Info: Applying configuration version '1552080757'
+Info: Creating state file /opt/puppetlabs/puppet/cache/state/state.yaml
+Notice: Applied catalog in 0.02 seconds
+Changes:
+Events:
+Resources:
+            Total: 7
+Time:
+         Schedule: 0.00
+   Transaction evaluation: 0.01
+   Catalog application: 0.02
+   Convert catalog: 0.07
+   Fact generation: 0.20
+      Plugin sync: 0.30
+   Node retrieval: 1.18
+   Config retrieval: 1.19
+         Last run: 1552080757
+       Filebucket: 0.00
+            Total: 2.99
+Version:
+           Config: 1552080757
+           Puppet: 6.3.1

     should be able to run an agent

+c.eco-emissary-99515.internal

     should have a report in puppetdb

+c.eco-emissary-99515.internal
+Revoked certificate for puppet_test986.c.eco-emissary-99515.internal
+Cleaned files related to puppet_test986.c.eco-emissary-99515.internal

     should be able to clean a certificate

```