### PR TITLE
(maint) Testing stability improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,15 +78,6 @@ steps:
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines(".env", $content, $Utf8NoBomEncoding)
     Get-Content -Path '.env'
-    Write-Host "Creating volumes directory structure in $ENV:TempVolumeRoot"
-    New-Item $ENV:TempVolumeRoot -Type Directory
-    Push-Location $ENV:TempVolumeRoot
-    New-Item 'volumes' -Type Directory
-    'volumes\code', 'volumes\puppet', 'volumes\serverdata', 'volumes\puppetdb\ssl', 'volumes\puppetdb-postgres\data' |
-      % { New-Item $_ -Type Directory }
-    Pop-Location
-    # Hack: grant all users access to this temp dir for the sake of Docker daemon
-    icacls $ENV:TempVolumeRoot /grant Users:"(OI)(CI)F" /T
     Write-Host 'Executing Pupperware specs'
     bundle exec rspec --version
     bundle exec rspec spec --fail-fast

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,13 +60,9 @@ steps:
     bundle install --with test --path '.bundle/gems'
     # make sure windows yml slots in as the default override
     Copy-Item ./docker-compose.windows.yml ./docker-compose.override.yml -Force
-    Write-Host 'Forcibly removing previous cluster config / data'
-    Remove-Item 'volumes' -Force -Recurse -ErrorAction SilentlyContinue;
-    New-Item 'volumes' -Type Directory
-    Push-Location 'volumes'
-    'code', 'puppet', 'serverdata', 'puppetdb\ssl', 'puppetdb-postgres\data' |
-      % { New-Item $_ -Type Directory }
-    Pop-Location
+    # set an Azure variable for temp volumes root
+    $tempVolumeRoot = Join-Path -Path $ENV:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
+    Write-Host "##vso[task.setvariable variable=TempVolumeRoot]$tempVolumeRoot"
   displayName: Prepare Test Environment
   name: test_prepare
 
@@ -77,10 +73,20 @@ steps:
     Write-Host 'Writing compose config to disk'
     $content = @"
     AZURE_DOMAIN=$domain
+    VOLUME_ROOT=$ENV:TempVolumeRoot
     "@
     $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
     [System.IO.File]::WriteAllLines(".env", $content, $Utf8NoBomEncoding)
     Get-Content -Path '.env'
+    Write-Host "Creating volumes directory structure in $ENV:TempVolumeRoot"
+    New-Item $ENV:TempVolumeRoot -Type Directory
+    Push-Location $ENV:TempVolumeRoot
+    New-Item 'volumes' -Type Directory
+    'volumes\code', 'volumes\puppet', 'volumes\serverdata', 'volumes\puppetdb\ssl', 'volumes\puppetdb-postgres\data' |
+      % { New-Item $_ -Type Directory }
+    Pop-Location
+    # Hack: grant all users access to this temp dir for the sake of Docker daemon
+    icacls $ENV:TempVolumeRoot /grant Users:"(OI)(CI)F" /T
     Write-Host 'Executing Pupperware specs'
     bundle exec rspec --version
     bundle exec rspec spec --fail-fast
@@ -100,6 +106,8 @@ steps:
     docker container prune --force
     Write-Host 'Pruning images'
     docker image prune --filter "dangling=true" --force
+    Write-Host "Cleaning up temporary volume: $ENV:TempVolumeRoot"
+    Remove-Item $ENV:TempVolumeRoot -Force -Recurse -ErrorAction Continue
   displayName: Container Cleanup
   timeoutInMinutes: 3
   condition: always()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,5 +4,5 @@ services:
   postgres:
     image: postgres:9.6
     volumes:
-      - ./volumes/puppetdb-postgres/data:/var/lib/postgresql/data/
+      - ${VOLUME_ROOT:-.}/volumes/puppetdb-postgres/data:/var/lib/postgresql/data/
       - ./postgres-custom:/docker-entrypoint-initdb.d

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -12,5 +12,5 @@ services:
     environment:
       - PGDATA=c:\data
     volumes:
-      - ./volumes/puppetdb-postgres/data:c:\data
+      - ${VOLUME_ROOT:-.}/volumes/puppetdb-postgres/data:c:\data
       - ./postgres-custom:c:\docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
-      - ./volumes/code:/etc/puppetlabs/code/
-      - ./volumes/puppet:/etc/puppetlabs/puppet/
-      - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - ${VOLUME_ROOT:-.}/volumes/code:/etc/puppetlabs/code/
+      - ${VOLUME_ROOT:-.}/volumes/puppet:/etc/puppetlabs/puppet/
+      - ${VOLUME_ROOT:-.}/volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
 
   postgres:
     environment:
@@ -43,7 +43,7 @@ services:
       - postgres
       - puppet
     volumes:
-      - ./volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - ${VOLUME_ROOT:-.}/volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
 
 networks:
   default:

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -26,12 +26,6 @@ describe 'The docker-compose file works' do
     end
   end
 
-  # only necessary on non-ephemeral hosts
-  def remove_volumes()
-    STDOUT.puts("Forcibly removing previous cluster config / data from #{VOLUME_ROOT}")
-    FileUtils.rm_rf(VOLUME_ROOT)
-  end
-
   def teardown_cluster
     STDOUT.puts("Tearing down test cluster")
     get_containers.each do |id|
@@ -40,8 +34,7 @@ describe 'The docker-compose file works' do
       run_command("docker container kill #{id}")
     end
     # still needed to remove network / provide failsafe
-    run_command('docker-compose --no-ansi down')
-    remove_volumes()
+    run_command('docker-compose --no-ansi down --volumes')
   end
 
   before(:all) do

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -21,6 +21,9 @@ describe 'The docker-compose file works' do
     ids = result[:stdout].chomp
     STDOUT.puts("Retrieved running container ids:\n#{ids}")
     ids.each_line do |id|
+      STDOUT.puts("Container logs for #{id}")
+      logs = run_command("docker logs --details --timestamps #{id}")[:stdout]
+      STDOUT.puts(logs)
       STDOUT.puts("Killing container #{id}")
       run_command("docker container kill #{id}")
     end

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -29,7 +29,6 @@ describe 'The docker-compose file works' do
   def teardown_cluster
     STDOUT.puts("Tearing down test cluster")
     get_containers.each do |id|
-      yield id if block_given?
       STDOUT.puts("Killing container #{id}")
       run_command("docker container kill #{id}")
     end
@@ -50,11 +49,8 @@ describe 'The docker-compose file works' do
   end
 
   after(:all) do
-    teardown_cluster() do |id|
-      STDOUT.puts("Container logs for #{id}")
-      logs = run_command("docker logs --details --timestamps #{id}")[:stdout]
-      STDOUT.puts(logs)
-    end
+    emit_logs()
+    teardown_cluster()
   end
 
   describe 'the cluster starts' do

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -6,49 +6,6 @@ shared_examples 'a running pupperware cluster' do
 
   include Helpers
 
-  def inspect_container(container, query)
-    result = run_command("docker inspect \"#{container}\" --format \"#{query}\"")
-    status = result[:stdout].chomp
-    STDOUT.puts "queried #{query} of #{container}: #{status}"
-    return status
-  end
-
-  def get_container_status(container)
-    inspect_container(container, '{{.State.Health.Status}}')
-  end
-
-  def get_service_container(service, timeout = 120)
-    result = run_command("docker-compose --no-ansi ps --quiet #{service}")
-    container = result[:stdout].chomp
-    Timeout::timeout(timeout) do
-      while container.empty?
-        sleep(1)
-        result = run_command("docker-compose --no-ansi ps --quiet #{service}")
-        container = result[:stdout].chomp
-      end
-    end
-
-    STDOUT.puts("service named '#{service}' is hosted in container: '#{container}'")
-    return container
-  rescue Timeout::Error
-    msg = "docker-compose never started a service named '#{service}'"
-    STDOUT.puts(msg)
-    raise msg
-  end
-
-  def get_service_base_uri(service, port)
-    @mapped_ports["#{service}:#{port}"] ||= begin
-      result = run_command("docker-compose --no-ansi port #{service} #{port}")
-      service_ip_port = result[:stdout].chomp
-      raise "Could not retrieve service endpoint for #{service}:#{port}" if service_ip_port == ''
-      uri = URI("http://#{service_ip_port}")
-      uri.host = 'localhost' if uri.host == '0.0.0.0'
-      STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
-      uri
-    end
-    @mapped_ports["#{service}:#{port}"]
-  end
-
   def get_puppetdb_state
     # make sure PDB container hasn't stopped
     get_service_container('puppetdb', 5)

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -6,11 +6,15 @@ shared_examples 'a running pupperware cluster' do
 
   include Helpers
 
-  def get_container_status(container)
-    result = run_command("docker inspect \"#{container}\" --format '{{.State.Health.Status}}'")
+  def inspect_container(container, query)
+    result = run_command("docker inspect \"#{container}\" --format \"#{query}\"")
     status = result[:stdout].chomp
-    STDOUT.puts "queried health status of #{container}: #{status}"
+    STDOUT.puts "queried #{query} of #{container}: #{status}"
     return status
+  end
+
+  def get_container_status(container)
+    inspect_container(container, '{{.State.Health.Status}}')
   end
 
   def get_service_container(service, timeout = 120)

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -62,9 +62,6 @@ shared_examples 'a running pupperware cluster' do
       status = get_container_status(container)
     end
 
-    # work around SERVER-2354
-    run_command('docker-compose --no-ansi exec puppet puppet config set server puppet')
-
     return status
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,47 @@ module Helpers
 
     { status: status, stdout: stdout_string }
   end
+
+  def inspect_container(container, query)
+    result = run_command("docker inspect \"#{container}\" --format \"#{query}\"")
+    status = result[:stdout].chomp
+    STDOUT.puts "queried #{query} of #{container}: #{status}"
+    return status
+  end
+
+  def get_container_status(container)
+    inspect_container(container, '{{.State.Health.Status}}')
+  end
+
+  def get_service_container(service, timeout = 120)
+    result = run_command("docker-compose --no-ansi ps --quiet #{service}")
+    container = result[:stdout].chomp
+    Timeout::timeout(timeout) do
+      while container.empty?
+        sleep(1)
+        result = run_command("docker-compose --no-ansi ps --quiet #{service}")
+        container = result[:stdout].chomp
+      end
+    end
+
+    STDOUT.puts("service named '#{service}' is hosted in container: '#{container}'")
+    return container
+  rescue Timeout::Error
+    msg = "docker-compose never started a service named '#{service}'"
+    STDOUT.puts(msg)
+    raise msg
+  end
+
+  def get_service_base_uri(service, port)
+    @mapped_ports["#{service}:#{port}"] ||= begin
+      result = run_command("docker-compose --no-ansi port #{service} #{port}")
+      service_ip_port = result[:stdout].chomp
+      raise "Could not retrieve service endpoint for #{service}:#{port}" if service_ip_port == ''
+      uri = URI("http://#{service_ip_port}")
+      uri.host = 'localhost' if uri.host == '0.0.0.0'
+      STDOUT.puts "determined #{service} endpoint for port #{port}: #{uri}"
+      uri
+    end
+    @mapped_ports["#{service}:#{port}"]
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,13 @@ module Helpers
     { status: status, stdout: stdout_string }
   end
 
+  def get_containers
+    result = run_command('docker-compose --no-ansi --log-level INFO ps -q')
+    ids = result[:stdout].chomp
+    STDOUT.puts("Retrieved running container ids:\n#{ids}")
+    ids.lines.map(&:chomp)
+  end
+
   def inspect_container(container, query)
     result = run_command("docker inspect \"#{container}\" --format \"#{query}\"")
     status = result[:stdout].chomp

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,22 @@ module Helpers
     inspect_container(container, '{{.State.Health.Status}}')
   end
 
+  def get_container_name(container)
+    inspect_container(container, '{{.Name}}')
+  end
+
+  def emit_log(container)
+    container_name = get_container_name(container)
+    STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
+    logs = run_command("docker logs --details --timestamps #{container}")[:stdout]
+    STDOUT.puts(logs)
+  end
+
+  def emit_logs
+    STDOUT.puts("Emitting container logs")
+    get_containers.each { |id| emit_log(id) }
+  end
+
   def get_service_container(service, timeout = 120)
     result = run_command("docker-compose --no-ansi ps --quiet #{service}")
     container = result[:stdout].chomp


### PR DESCRIPTION
 - No longer need to set the server name to puppet for SERVER-2354 given this
   issue was fixed in puppetserver 6.1
 - Refactor container inspection helper to be more generic
 - Fail more quickly when PDB has problems standing up, but still allow for connectivity issues while it's starting when access the health check (EOF, connection refused, connection reset)
 - Always emit docker logs for containers when tearing down the cluster
 - Refactor the teardown so that it can be performed before the suite *and* after the suite
 - Allow for configuring the root directory of the volume mount (primarily for long-lived CI boxes so that files aren't jammed inside the checked out source directory)
 - Move the volume creation / cleanup inside the spec suite