### PR TITLE
(maint) Minor test improvements / always pull latest containers / Windows README update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.22.0
+    - DOCKER_COMPOSE_VERSION=1.24.0
     - COMPOSE_PROJECT_NAME=pupperware
 
 before_install:

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -46,6 +46,8 @@ describe 'The docker-compose file works' do
     end
     teardown_cluster()
     create_volumes()
+    # ensure all containers are latest versions
+    run_command('docker-compose --no-ansi pull --quiet')
   end
 
   after(:all) do

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -40,7 +40,7 @@ describe 'The docker-compose file works' do
     @test_agent = "puppet_test#{Random.rand(1000)}"
     @mapped_ports = {}
     @timestamps = []
-    status = run_command('docker-compose --no-ansi --help')[:status]
+    status = run_command('docker-compose --no-ansi version')[:status]
     if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end


### PR DESCRIPTION
* Switches Travis to docker-compose 1.24.0
* Adds additional notes to README for LCOW v2
* Make sure to always pull the latest containers by using `docker-compose pull` at the onset
* Minor test output cleanup by using `docker-compose version` instead of `docker-compose --help` when starting suite