### PR TITLE
(MAINT) SSL sidecar container

### DIFF
--- a/shared/getcerts.sh
+++ b/shared/getcerts.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Used by a "sidecar" container to get SSL certificates for the
+# parent container.
+#
+# Required environment variables:
+#   CERTNAME      Subject name to get a certificate for
+#   SSLDIR        Directory on disk to store the SSL certificates and keys
+#
+# Optional environment variables:
+#   SSLDIR_UID             Desired owner UID of the SSLDIR
+#   SSLDIR_GID             Desired group GID of the SSLDIR
+#   PUPPETSERVER_HOSTNAME  Hostname of Puppet Server CA, defaults to "puppet"
+#   CONSUL_ENABLED         Whether to query Consul for Puppet Server status,
+#                          defaults to false
+#   CONSUL_HOSTNAME        Hostname of the Consul server, defaults to "consul"
+#   CONSUL_PORT            Port of Consul server, defaults to 8500
+
+CERTNAME=${CERTNAME?}
+SSLDIR=${SSLDIR?}
+SSLDIR_UID=${SSLDIR_UID}
+SSLDIR_GID=${SSLDIR_GID}
+
+PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
+CONSUL_HOSTNAME="${CONSUL_HOSTNAME:-consul}"
+CONSUL_PORT="${CONSUL_PORT:-8500}"
+
+master_running() {
+    if [ "$CONSUL_ENABLED" = "true" ]; then
+        status=$(curl --silent --fail \
+            "http://${CONSUL_HOSTNAME}:${CONSUL_PORT}/v1/health/checks/puppet" \
+            | grep -q '"Status": "passing"')
+        test "$?" = "0"
+    else
+        status=$(curl --silent --fail --insecure \
+            "https://${PUPPETSERVER_HOSTNAME}:8140/status/v1/simple")
+        test "$status" = "running"
+    fi
+}
+
+if [ ! -f "${SSLDIR}/certs/${CERTNAME}.pem" ]; then
+    while ! master_running; do
+        echo "Waiting for CA to be up to get SSL certificate for ${CERTNAME}..."
+        sleep 1
+    done
+    set -e
+    SSLDIR=$SSLDIR /ssl.sh $CERTNAME
+
+    # Set the SSLDIR ownership if a UID and GID have been provided
+    if [ ! -z $SSLDIR_UID ] && [ ! -z $SSLDIR_GID ]; then
+        chown -R $SSLDIR_UID:$SSLDIR_GID $SSLDIR
+    fi
+fi

--- a/ssl-sidecar/Dockerfile
+++ b/ssl-sidecar/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.9
+ENV PACKAGES "gettext curl openssl ca-certificates"
+RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
+COPY shared/ssl.sh /ssl.sh
+COPY shared/getcerts.sh /getcerts.sh
+ENTRYPOINT ["/getcerts.sh"]

--- a/ssl-sidecar/Dockerfile
+++ b/ssl-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 ENV PACKAGES "gettext curl openssl ca-certificates"
-RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
+RUN apk add --no-cache $PACKAGES
 COPY shared/ssl.sh /ssl.sh
 COPY shared/getcerts.sh /getcerts.sh
 ENTRYPOINT ["/getcerts.sh"]

--- a/ssl-sidecar/Dockerfile
+++ b/ssl-sidecar/Dockerfile
@@ -1,6 +1,24 @@
 FROM alpine:3.9
+ARG vcs_ref
+ARG build_date
+ARG version="latest"
 ENV PACKAGES "gettext curl openssl ca-certificates"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/pupperware" \
+      org.label-schema.name="SSL Sidecar" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version="$version" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/pupperware" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+
 RUN apk add --no-cache $PACKAGES
 COPY shared/ssl.sh /ssl.sh
 COPY shared/getcerts.sh /getcerts.sh
 ENTRYPOINT ["/getcerts.sh"]
+
+COPY ssl-sidecar/Dockerfile /

--- a/ssl-sidecar/Makefile
+++ b/ssl-sidecar/Makefile
@@ -1,0 +1,37 @@
+NAMESPACE ?= puppet
+vcs_ref := $(shell git rev-parse HEAD)
+build_date := $(shell date -u +%FT%T)
+version := latest
+dockerfile := Dockerfile
+hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
+hadolint_command := hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001
+hadolint_container := hadolint/hadolint:latest
+
+lint:
+ifeq ($(hadolint_available),0)
+	@$(hadolint_command) $(dockerfile)
+else
+	@docker pull $(hadolint_container)
+	@docker run --rm -v $(PWD)/$(dockerfile):/Dockerfile \
+		-i $(hadolint_container) $(hadolint_command) Dockerfile
+endif
+
+build:
+	@docker build \
+		--pull \
+		--build-arg vcs_ref=$(vcs_ref) \
+		--build-arg build_date=$(build_date) \
+		--build-arg version=$(version) \
+		--file $(dockerfile) \
+	  --tag $(NAMESPACE)/ssl-sidecar:$(version) \
+		..
+
+test:
+	@echo "TODO: spec tests"
+
+push-image:
+	@docker push $(NAMESPACE)/ssl-sidecar:$(version)
+
+publish: push-image
+
+.PHONY: lint build test publish push-image

--- a/ssl-sidecar/distelli-manifest.yml
+++ b/ssl-sidecar/distelli-manifest.yml
@@ -1,0 +1,9 @@
+pe-and-platform/ssl-sidecar:
+  PreBuild:
+    - make lint
+  Build:
+    - make build
+    - make test
+  AfterBuildSuccess:
+    - docker login -u "$DISTELLI_DOCKER_USERNAME" -p "$DISTELLI_DOCKER_PW" "$DISTELLI_DOCKER_ENDPOINT"
+    - make publish


### PR DESCRIPTION
Rather than copy these scripts around everywhere.

To build, run the following from the root of the repository:

   docker build -t puppet/ssl-sidecar -f ssl-sidecar/Dockerfile .