### PR TITLE
(maint) Testing improvements / refactors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,6 +97,10 @@ steps:
     docker container prune --force
     Write-Host 'Pruning images'
     docker image prune --filter "dangling=true" --force
+    Write-Host "Pruning Volumes"
+    docker volume prune
+    Write-Host "Pruning Networks"
+    docker network prune
     Write-Host "Cleaning up temporary volume: $ENV:TempVolumeRoot"
     Remove-Item $ENV:VOLUME_ROOT -Force -Recurse -ErrorAction Continue
   displayName: Container Cleanup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ steps:
     Copy-Item ./docker-compose.windows.yml ./docker-compose.override.yml -Force
     # set an Azure variable for temp volumes root
     $tempVolumeRoot = Join-Path -Path $ENV:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
-    Write-Host "##vso[task.setvariable variable=TempVolumeRoot]$tempVolumeRoot"
+    Write-Host "##vso[task.setvariable variable=VOLUME_ROOT]$tempVolumeRoot"
   displayName: Prepare Test Environment
   name: test_prepare
 
@@ -98,7 +98,7 @@ steps:
     Write-Host 'Pruning images'
     docker image prune --filter "dangling=true" --force
     Write-Host "Cleaning up temporary volume: $ENV:TempVolumeRoot"
-    Remove-Item $ENV:TempVolumeRoot -Force -Recurse -ErrorAction Continue
+    Remove-Item $ENV:VOLUME_ROOT -Force -Recurse -ErrorAction Continue
   displayName: Container Cleanup
   timeoutInMinutes: 3
   condition: always()

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -13,16 +13,6 @@ describe 'The docker-compose file works' do
     'volumes/puppetdb-postgres/data'
   ]
 
-  def teardown_cluster
-    STDOUT.puts("Tearing down test cluster")
-    get_containers.each do |id|
-      STDOUT.puts("Killing container #{id}")
-      run_command("docker container kill #{id}")
-    end
-    # still needed to remove network / provide failsafe
-    run_command('docker-compose --no-ansi down --volumes')
-  end
-
   before(:all) do
     @test_agent = "puppet_test#{Random.rand(1000)}"
     @mapped_ports = {}

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -3,7 +3,7 @@
 require "#{File.join(File.dirname(__FILE__), 'examples', 'running_cluster.rb')}"
 
 describe 'The docker-compose file works' do
-  include Helpers
+  include Pupperware::SpecHelpers
 
   VOLUMES = [
     'volumes/code',

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -6,25 +6,12 @@ describe 'The docker-compose file works' do
   include Helpers
 
   VOLUMES = [
-    'code',
-    'puppet',
-    'serverdata',
-    'puppetdb/ssl',
-    'puppetdb-postgres/data'
+    'volumes/code',
+    'volumes/puppet',
+    'volumes/serverdata',
+    'volumes/puppetdb/ssl',
+    'volumes/puppetdb-postgres/data'
   ]
-
-  DEFAULT_VOLUME_ROOT = File.join(File.dirname(__FILE__), '..')
-  VOLUME_ROOT = File.join(ENV['TempVolumeRoot'] || DEFAULT_VOLUME_ROOT, 'volumes')
-
-  def create_volumes()
-    STDOUT.puts("Creating volumes directory structure in #{VOLUME_ROOT}")
-    VOLUMES.each { |subdir| FileUtils.mkdir_p(File.join(VOLUME_ROOT, subdir)) }
-
-    if !!File::ALT_SEPARATOR
-      # Hack: grant all users access to this temp dir for the sake of Docker daemon
-      run_command("icacls \"#{VOLUME_ROOT}\" /grant Users:\"(OI)(CI)F\" /T")
-    end
-  end
 
   def teardown_cluster
     STDOUT.puts("Tearing down test cluster")
@@ -45,7 +32,8 @@ describe 'The docker-compose file works' do
       fail "`docker-compose` must be installed and available in your PATH"
     end
     teardown_cluster()
-    create_volumes()
+    # LCOW requires directories to exist
+    create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
     # ensure all containers are latest versions
     run_command('docker-compose --no-ansi pull --quiet')
   end

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -15,7 +15,6 @@ describe 'The docker-compose file works' do
 
   before(:all) do
     @test_agent = "puppet_test#{Random.rand(1000)}"
-    @mapped_ports = {}
     @timestamps = []
     status = run_command('docker-compose --no-ansi version')[:status]
     if status.exitstatus != 0

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -44,11 +44,9 @@ describe 'The docker-compose file works' do
     # don't run this on Windows because compose down takes forever
     # https://github.com/docker/for-win/issues/629
     it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
-      ps = run_command('docker-compose --no-ansi ps')[:stdout].chomp
-      expect(ps.match('puppet')).not_to eq(nil)
+      expect(get_containers()).not_to be_empty
       run_command('docker-compose --no-ansi down')
-      ps = run_command('docker-compose --no-ansi ps')[:stdout].chomp
-      expect(ps.match('puppet')).to eq(nil)
+      expect(get_containers()).to be_empty
     end
 
     include_examples 'a running pupperware cluster'

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -1,12 +1,18 @@
+shared_context "running_cluster", :shared_context => :metadata do
+  include Pupperware::SpecHelpers
+
+  before(:each) do
+    run_command('docker-compose --no-ansi up --detach')
+    wait_on_postgres_db('puppetdb')
+  end
+end
+
 shared_examples 'a running pupperware cluster' do
   require 'rspec/core'
 
-  include Pupperware::SpecHelpers
+  include_context 'running_cluster'
 
   it 'should start all of the cluster services' do
-    run_command('docker-compose --no-ansi up --detach')
-    wait_on_postgres_db('puppetdb')
-
     expect(get_service_container('puppet', 120)).to_not be_empty
     expect(get_service_container('postgres', 60)).to_not be_empty
     expect(get_service_container('puppetdb', 60)).to_not be_empty

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -16,7 +16,7 @@ shared_examples 'a running pupperware cluster' do
       when Net::HTTPSuccess then
         return JSON.parse(response.body)['state']
       else
-       return ''
+        return ''
     end
   rescue Errno::ECONNREFUSED, Errno::ECONNRESET, EOFError => e
     STDOUT.puts "PDB not accepting connections yet #{pdb_uri}: #{e}"

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -41,28 +41,6 @@ shared_examples 'a running pupperware cluster' do
     return status
   end
 
-  def count_postgres_database(database)
-    cmd = "docker-compose --no-ansi exec -T postgres psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
-    run_command(cmd)[:stdout].strip
-  end
-
-  def wait_on_postgres_db(database, seconds = 240)
-    return retry_block_up_to_timeout(seconds) do
-      count_postgres_database('puppetdb') == '1' ? '1' :
-        raise("database #{database} never created")
-    end
-  end
-
-  def get_postgres_extensions
-    return retry_block_up_to_timeout(30) do
-      query = 'docker-compose --no-ansi exec -T postgres psql --username=puppetdb --command="SELECT * FROM pg_extension"'
-      extensions = run_command(query)[:stdout].chomp
-      raise('failed to retrieve extensions') if extensions.empty?
-      STDOUT.puts("retrieved extensions: #{extensions}")
-      extensions
-    end
-  end
-
   def run_agent(agent_name)
     # setting up a Windows TTY is difficult, so we don't
     # allocating a TTY will show container pull output on Linux, but that's not good for tests

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -5,15 +5,6 @@ shared_examples 'a running pupperware cluster' do
 
   include Pupperware::SpecHelpers
 
-  def wait_on_puppetserver_status(seconds = 180)
-    # puppetserver has a healthcheck, we can let that deal with timeouts
-    return retry_block_up_to_timeout(seconds) do
-      status = get_container_status(get_service_container('puppet'))
-      (status == 'healthy' || status == "'healthy'") ? 'healthy' :
-        raise("puppetserver stuck in #{status}")
-    end
-  end
-
   def run_agent(agent_name)
     # setting up a Windows TTY is difficult, so we don't
     # allocating a TTY will show container pull output on Linux, but that's not good for tests
@@ -39,14 +30,6 @@ shared_examples 'a running pupperware cluster' do
         JSON.parse(out).first['report_timestamp']
       end
     end
-  end
-
-  def clean_certificate(agent_name)
-    result = run_command('docker-compose --no-ansi exec -T puppet facter domain')
-    domain = result[:stdout].chomp
-    STDOUT.puts "cleaning cert for #{agent_name}.#{domain}"
-    result = run_command("docker-compose --no-ansi exec -T puppet puppetserver ca clean --certname #{agent_name}.#{domain}")
-    return result[:status].exitstatus
   end
 
   it 'should start all of the cluster services' do

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -7,14 +7,9 @@ shared_examples 'a running pupperware cluster' do
     run_command('docker-compose --no-ansi up --detach')
     wait_on_postgres_db('puppetdb')
 
-    result = run_command('docker-compose --no-ansi ps puppet')
-    expect(result[:status].exitstatus).to eq(0), "service puppet not found: #{result[:stdout].chomp}"
-
-    result = run_command('docker-compose --no-ansi ps puppetdb')
-    expect(result[:status].exitstatus).to eq(0), "service puppetdb not found: #{result[:stdout].chomp}"
-
-    result = run_command('docker-compose --no-ansi ps postgres')
-    expect(result[:status].exitstatus).to eq(0), "service postgres not found: #{result[:stdout].chomp}"
+    expect(get_service_container('puppet', 120)).to_not be_empty
+    expect(get_service_container('postgres', 60)).to_not be_empty
+    expect(get_service_container('puppetdb', 60)).to_not be_empty
   end
 
   it 'should start puppetserver' do

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -3,7 +3,7 @@ shared_examples 'a running pupperware cluster' do
   require 'rspec/core'
   require 'net/http'
 
-  include Helpers
+  include Pupperware::SpecHelpers
 
   def get_puppetdb_state
     # make sure PDB container hasn't stopped

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -41,11 +41,26 @@ shared_examples 'a running pupperware cluster' do
     return status
   end
 
+  def count_postgres_database(database)
+    cmd = "docker-compose --no-ansi exec -T postgres psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
+    run_command(cmd)[:stdout].strip
+  end
+
+  def wait_on_postgres_db(database, seconds = 240)
+    return retry_block_up_to_timeout(seconds) do
+      count_postgres_database('puppetdb') == '1' ? '1' :
+        raise("database #{database} never created")
+    end
+  end
+
   def get_postgres_extensions
-    result = run_command('docker-compose --no-ansi exec -T postgres psql --username=puppetdb --command="SELECT * FROM pg_extension"')
-    extensions = result[:stdout].chomp
-    STDOUT.puts("retrieved extensions: #{extensions}")
-    extensions
+    return retry_block_up_to_timeout(30) do
+      query = 'docker-compose --no-ansi exec -T postgres psql --username=puppetdb --command="SELECT * FROM pg_extension"'
+      extensions = run_command(query)[:stdout].chomp
+      raise('failed to retrieve extensions') if extensions.empty?
+      STDOUT.puts("retrieved extensions: #{extensions}")
+      extensions
+    end
   end
 
   def run_agent(agent_name)
@@ -94,6 +109,8 @@ shared_examples 'a running pupperware cluster' do
 
   it 'should start all of the cluster services' do
     run_command('docker-compose --no-ansi up --detach')
+    wait_on_postgres_db('puppetdb')
+
     result = run_command('docker-compose --no-ansi ps puppet')
     expect(result[:status].exitstatus).to eq(0), "service puppet not found: #{result[:stdout].chomp}"
 

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -1,36 +1,7 @@
 shared_examples 'a running pupperware cluster' do
-  require 'json'
   require 'rspec/core'
-  require 'net/http'
 
   include Pupperware::SpecHelpers
-
-  def run_agent(agent_name)
-    # setting up a Windows TTY is difficult, so we don't
-    # allocating a TTY will show container pull output on Linux, but that's not good for tests
-    result = run_command("docker run --rm --network pupperware_default --name #{agent_name} --hostname #{agent_name} puppet/puppet-agent-alpine")
-    return result[:status].exitstatus
-  end
-
-  def check_report(agent_name)
-    pdb_uri = URI::join(get_service_base_uri('puppetdb', 8080), '/pdb/query/v4')
-    result = run_command("docker-compose --no-ansi exec -T puppet facter domain")
-    domain = result[:stdout].chomp
-    body = "{ \"query\": \"nodes { certname = \\\"#{agent_name}.#{domain}\\\" } \" }"
-
-    return retry_block_up_to_timeout(120) do
-      Net::HTTP.start(pdb_uri.hostname, pdb_uri.port) do |http|
-        req = Net::HTTP::Post.new(pdb_uri)
-        req.content_type = 'application/json'
-        req.body = body
-        res =  http.request(req)
-        out = res.body if res.code == '200' && !res.body.empty?
-        STDOUT.puts "retrieved agent #{agent_name} report info from #{req.uri}: HTTP #{res.code} /  #{res.body}"
-        raise('empty PDB report received') if out.nil? || out.empty?
-        JSON.parse(out).first['report_timestamp']
-      end
-    end
-  end
 
   it 'should start all of the cluster services' do
     run_command('docker-compose --no-ansi up --detach')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,11 @@ module Helpers
 
     Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
       Thread.new do
+        Thread.current.report_on_exception = false
         stdout.each { |l| stdout_string << l; STDOUT.puts l }
       end
       Thread.new do
+        Thread.current.report_on_exception = false
         stderr.each { |l| STDOUT.puts l }
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,4 +109,14 @@ module Helpers
     end
     @mapped_ports["#{service}:#{port}"]
   end
+
+  def teardown_cluster
+    STDOUT.puts("Tearing down test cluster")
+    get_containers.each do |id|
+      STDOUT.puts("Killing container #{id}")
+      run_command("docker container kill #{id}")
+    end
+    # still needed to remove network / provide failsafe
+    run_command('docker-compose --no-ansi down --volumes')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,14 @@
 require 'open3'
 
 module Helpers
-  def run_command(command)
+  def run_command(env = ENV.to_h, command)
     stdout_string = ''
     status = nil
 
-    Open3.popen3(command) do |stdin, stdout, stderr, wait_thread|
+    Open3.popen3(env, command) do |stdin, stdout, stderr, wait_thread|
       Thread.new do
         Thread.current.report_on_exception = false
-        stdout.each { |l| stdout_string << l; STDOUT.puts l }
+        stdout.each { |l| stdout_string << l and STDOUT.puts l }
       end
       Thread.new do
         Thread.current.report_on_exception = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,7 @@ module Helpers
   end
 
   def get_service_base_uri(service, port)
+    @mapped_ports ||= {}
     @mapped_ports["#{service}:#{port}"] ||= begin
       result = run_command("docker-compose --no-ansi port #{service} #{port}")
       service_ip_port = result[:stdout].chomp

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,5 +134,32 @@ module SpecHelpers
     STDOUT.puts("Emitting container logs")
     get_containers.each { |id| emit_log(id) }
   end
+
+  ######################################################################
+  # Postgres Helpers
+  ######################################################################
+
+  def count_postgres_database(database)
+    cmd = "docker-compose --no-ansi exec -T postgres psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
+    run_command(cmd)[:stdout].strip
+  end
+
+  def wait_on_postgres_db(database, seconds = 240)
+    return retry_block_up_to_timeout(seconds) do
+      count_postgres_database('puppetdb') == '1' ? '1' :
+        raise("database #{database} never created")
+    end
+  end
+
+  def get_postgres_extensions
+    return retry_block_up_to_timeout(30) do
+      query = 'docker-compose --no-ansi exec -T postgres psql --username=puppetdb --command="SELECT * FROM pg_extension"'
+      extensions = run_command(query)[:stdout].chomp
+      raise('failed to retrieve extensions') if extensions.empty?
+      STDOUT.puts("retrieved extensions: #{extensions}")
+      extensions
+    end
+  end
+
 end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'timeout'
 
 module Helpers
   def run_command(env = ENV.to_h, command)
@@ -20,6 +21,24 @@ module Helpers
     end
 
     { status: status, stdout: stdout_string }
+  end
+
+  def retry_block_up_to_timeout(timeout, &block)
+    ex = nil
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    loop do
+      begin
+        return yield
+      rescue => e
+        ex = e
+        sleep(1)
+      ensure
+        if (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) > timeout
+          raise Timeout::Error.new(ex)
+        end
+      end
+    end
   end
 
   def get_containers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,16 @@ module Helpers
     end
   end
 
+  # Windows requires directories to exist prior, whereas Linux will create them
+  def create_host_volume_targets(root, volumes)
+    return unless !!File::ALT_SEPARATOR
+
+    STDOUT.puts("Creating volumes directory structure in #{root}")
+    volumes.each { |subdir| FileUtils.mkdir_p(File.join(root, subdir)) }
+    # Hack: grant all users access to this temp dir for the sake of Docker daemon
+    run_command("icacls \"#{root}\" /grant Users:\"(OI)(CI)F\" /T")
+  end
+
   def get_containers
     result = run_command('docker-compose --no-ansi --log-level INFO ps -q')
     ids = result[:stdout].chomp


### PR DESCRIPTION
- Ruby added a feature to report on all exceptions in threads.

   Intermittently the suite will terminate a reader thread inside of
   run_command and log it, confusing the results of the suite output
   in CI with a message like:

##[error]bundle : #<Thread:0x0000000002944ee8@C:/agent/_work/6/s/docker/puppetdb/spec/spec_helper.rb:10 run> terminated with
##[error]exception (report_on_exception is true):

##[error]At C:\agent\_work\6\s\docker\ci\build.ps1:60 char:3

 - Turn off this new feature inside each reader thread. More info on
   this functionality is in:

  blog.bigbinary.com/2018/04/18/ruby-2-5-enables-thread-report_on_exception-by-default.html

- Add env var support to Docker run_command

- Remove usage of Timeout in favor of the `retry_block_up_to_timeout` helper

- Only create temp host volume targets on Windows for the sake of Azure... 

- Move all shared helpers to the SpecHelper (which is renamed `Pupperware::SpecHelper`

- Restructure specs a bit around the notion of a shared context (i.e. the cluster being up with containers running). Initially just wait for the `puppetdb` database to show up in Postgres

- Make the Puppetserver liveness check have a timeout

- As much simplification of the test code as possible