### PR TITLE
(maint) Make PDB container wait longer on Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
+      - PUPPETDB_WAITFORPOSTGRES_SECONDS=150
     volumes:
       - ${VOLUME_ROOT:-.}/volumes/code:/etc/puppetlabs/code/
       - ${VOLUME_ROOT:-.}/volumes/puppet:/etc/puppetlabs/puppet/


### PR DESCRIPTION
This is another approach to the PR against PDB at https://github.com/puppetlabs/puppetdb/pull/2904

 - PDB has a configurable wait time on Postgres when it is starting up, which
   defaults to 90 seconds

   This doesn't appear to be long enough in Azure based on failures like:

```
   wtfc.sh: waiting 90 seconds for nc -v -w 1 -z 'postgres' 5432
   .........................................................................................(/docker-entrypoint.d/20-wait-for-hosts.sh) Error: host postgres:5432 does not appear to be listening
   wtfc.sh: timeout occurred after waiting 90 seconds for nc -v -w 1 -z 'postgres' 5432 to return status: 0 (was status: 143)
```