### PR TITLE
(maint) Allow specifying a master for agent runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     image: puppet/puppetdb
     environment:
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
+      # This name is an FQDN so the short name puppet doesn't collide outside compose network
+      - PUPPETSERVER_HOSTNAME=puppet.${AZURE_DOMAIN:-}
       - PUPPETDB_PASSWORD=puppetdb
       - PUPPETDB_USER=puppetdb
     ports:


### PR DESCRIPTION
 - `puppet agent` allows for specifying a master, which has been
   defaulted to `puppet` this far, which will not work in many
   scenarios (for instance, when running in internal environments)
   where the name `puppet` is an existing master

   Default to looking for the `puppet` service in the compose stack
   and resolving that node to a FQDN to supply to the agents.

   This approach should be more flexible

 - Rather than use the SSL script to curl against `puppet`, supply the
   configured DNS alias for uniqueness

 - This specifically addresses a problem where the name `puppet`
   resolves to a host outside the compose network instead of the desired
   container inside the docker compose network. (Docker docs imply
   the container named `puppet` should be preferred, and it's unclear why
   it is not)

   There may be a misconfiguration or other Docker bug at play here
   (perhaps specific to LCOW)