### PR TITLE
(maint) Add helpers for running stand-alone docker containers

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -126,6 +126,21 @@ module SpecHelpers
     inspect_container(container, '{{.Name}}')
   end
 
+  def get_container_status(container)
+    inspect_container(container, '{{.State.Status}}')
+  end
+
+  def get_container_exit_code(container)
+    inspect_container(container, '{{.State.ExitCode}}').to_i
+  end
+
+  def wait_on_container_exit(container, timeout = 60)
+    return retry_block_up_to_timeout(timeout) do
+      get_container_status(container) == 'exited' ? 'exited' :
+        raise('container never exited')
+    end
+  end
+
   def get_container_hostname(container)
     # '{{json .NetworkSettings.Networks}}' useful in debug
     # returns all aliases in a Go array like [foo bar baz], so turn into Ruby array to inspect
@@ -147,6 +162,11 @@ module SpecHelpers
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
     logs = run_command("docker logs --details --timestamps #{container}")[:stdout]
     STDOUT.puts(logs)
+  end
+
+  def teardown_container(container)
+    STDOUT.puts("Tearing down test container")
+    run_command("docker container rm --force #{container}")
   end
 
   def emit_logs

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -100,8 +100,7 @@ module SpecHelpers
   def teardown_cluster
     STDOUT.puts("Tearing down test cluster")
     get_containers.each do |id|
-      STDOUT.puts("Killing container #{id}")
-      run_command("docker container kill #{id}")
+      teardown_container(id)
     end
     # still needed to remove network / provide failsafe
     run_command('docker-compose --no-ansi down --volumes')

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -125,7 +125,7 @@ module SpecHelpers
     inspect_container(container, '{{.Name}}')
   end
 
-  def get_container_status(container)
+  def get_container_state(container)
     inspect_container(container, '{{.State.Status}}')
   end
 
@@ -135,7 +135,7 @@ module SpecHelpers
 
   def wait_on_container_exit(container, timeout = 60)
     return retry_block_up_to_timeout(timeout) do
-      get_container_status(container) == 'exited' ? 'exited' :
+      get_container_state(container) == 'exited' ? 'exited' :
         raise('container never exited')
     end
   end


### PR DESCRIPTION
This will allow us to standardize tests for containers where it doesn't
make sense to run a compose stack in tests (i.e., r10k)