### PR TITLE
(revert) changes to k8s yaml to use .internal DNS

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -14,7 +14,7 @@ running Kubernetes via Docker for Mac, this will be the FQDN of your Mac. Note t
 
 ```yaml
   - name: DNS_ALT_NAMES
-    value: puppet,puppet.internal,myworkstation.domain.net
+    value: puppet,myworkstation.domain.net
 ```
 
 Then create the Pupperware resources:

--- a/k8s/bin/puppet-query
+++ b/k8s/bin/puppet-query
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-kubectl get pods --selector=svc=puppetdb -o name | cut -d '/' -f 2 | xargs -I '%' kubectl exec '%' -- curl -s -X GET http://puppetdb.internal:8080/pdb/query/v4 --data-urlencode "query=$@"
+kubectl get pods --selector=svc=puppetdb -o name | cut -d '/' -f 2 | xargs -I '%' kubectl exec '%' -- curl -s -X GET http://puppetdb:8080/pdb/query/v4 --data-urlencode "query=$@"

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -44,7 +44,7 @@ spec:
         app: pupperware
         svc: postgres
     spec:
-      hostname: postgres.internal
+      hostname: postgres
       containers:
         - image: puppet/puppetdb-postgres
           name: postgres

--- a/k8s/puppetdb.yaml
+++ b/k8s/puppetdb.yaml
@@ -47,15 +47,15 @@ spec:
         app: pupperware
         svc: puppetdb
     spec:
-      hostname: puppetdb.internal
+      hostname: puppetdb
       containers:
         - image: puppet/puppetdb
           name: puppetdb
           env:
             - name: PUPPETSERVER_HOSTNAME
-              value: puppet.internal
+              value: puppet
             - name: PUPPETDB_POSTGRES_HOSTNAME
-              value: postgres.internal
+              value: postgres
             - name: PUPPETDB_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k8s/puppetserver.yaml
+++ b/k8s/puppetserver.yaml
@@ -71,7 +71,7 @@ spec:
         app: pupperware
         svc: puppet
     spec:
-      hostname: puppet.internal
+      hostname: puppet
       containers:
         - image: puppet/puppetserver
           name: puppet
@@ -79,11 +79,11 @@ spec:
             # necessary to set certname and server in puppet.conf, required by
             # puppetserver ca cli application
             - name: PUPPETSERVER_HOSTNAME
-              value: puppet.internal
+              value: puppet
             - name: DNS_ALT_NAMES
-              value: puppet,puppet.internal
+              value: puppet
             - name: PUPPETDB_SERVER_URLS
-              value: https://puppetdb.internal:8081
+              value: https://puppetdb:8081
           ports:
             - containerPort: 8140
           volumeMounts:


### PR DESCRIPTION
 - k8s already has DNS sorted out appropriately where applicable, so
   unlike docker-compose, it doesn't need to have as restrictive
   a network setup

   This reverts 065352876bd578e566bdf19eb2c3dc3cc62f061f changes that
   were made to both the docker-compose stack *and* k8s stack