### PR TITLE
(maint) Switch K8S to use the postgres docker image

### DIFF
--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -25,6 +25,17 @@ spec:
     requests:
       storage: 100Mi
 ---
+apiVersion: v1
+data:
+  extensions.sql: |
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+kind: ConfigMap
+metadata:
+  name: postgres-custom-extensions
+  labels:
+    app: pupperware
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +57,7 @@ spec:
     spec:
       hostname: postgres
       containers:
-        - image: puppet/puppetdb-postgres
+        - image: postgres:9.6
           name: postgres
           env:
             - name: POSTGRES_PASSWORD
@@ -59,13 +70,20 @@ spec:
                 secretKeyRef:
                   name: puppetdb
                   key: user
+            - name: POSTGRES_DB
+              value: puppetdb
           ports:
             - name: postgres
               containerPort: 5432
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data/
+            - name: postgres-custom-extensions
+              mountPath: /docker-entrypoint-initdb.d/postgres-custom
       volumes:
         - name: postgres-storage
           persistentVolumeClaim:
             claimName: postgres-claim
+        - name: postgres-custom-extensions
+          configMap:
+            name: postgres-custom-extensions


### PR DESCRIPTION
Prior to this PR, the k8s configuration leveraged `the puppet/puppetdb-postgres` image, whereas the `docker-compose` configuration was using the `postgres:9.6` image. This commit aligns the
container images with the docker-compose configuration by switching k8s to use `postgres:9.6`.

The root of this change comes from #50. The biggest difference is that the config map is defined in the manifest rather than the `postgres-custom/extensions.sql` files on disk.