### PR TITLE
(maint) Pin to Postgres 9.6.13 to address bug in 9.6.14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
          - puppet.${DOMAIN:-internal}
 
   postgres:
-    image: postgres:9.6
+    image: postgres:9.6.13
     environment:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb


### PR DESCRIPTION
This pin can be reverted when a new 9.6 container is released with a fix
for the bug discussed at
https://www.postgresql.org/message-id/15865-17940eacc8f8b081%40postgresql.org