### PR TITLE
(MAINT) Fix Distelli failure

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'net/http'
 require 'open3'
 require 'timeout'
+require 'openssl'
 
 module Pupperware
 module SpecHelpers


### PR DESCRIPTION
Somehow we missed this require statement and we've survived this long,
but things are now failing in Distelli because OpenSSL is uninitialized.