### PR TITLE
(maint) Create generic service HEALTHCHECK waiter

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -262,6 +262,7 @@ module SpecHelpers
   # PuppetDB Helpers
   ######################################################################
 
+  # @deprecated - remove method once all callers are updated
   def get_puppetdb_state
     # make sure PDB container hasn't stopped
     get_service_container('puppetdb', 5)
@@ -286,13 +287,9 @@ module SpecHelpers
     raise
   end
 
+  # @deprecated - remove method once all callers are updated
   def wait_on_puppetdb_status(seconds = 240)
-    # since pdb doesn't have a proper healthcheck yet, this could spin forever
-    # add a timeout so it eventually returns.
-    return retry_block_up_to_timeout(seconds) do
-      get_puppetdb_state() == 'running' ? 'running' :
-        raise('puppetdb never entered running state')
-    end
+    wait_on_service_health('puppetdb', seconds)
   end
 
   ######################################################################

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -190,6 +190,15 @@ module SpecHelpers
     end
   end
 
+  def wait_on_service_health(service, seconds = 180)
+    # services with healthcheck should deal with their own timeouts
+    return retry_block_up_to_timeout(seconds) do
+      status = get_container_status(get_service_container(service))
+      (status == 'healthy' || status == "'healthy'") ? 'healthy' :
+        raise("#{service} is not healthy - currently #{status}")
+    end
+  end
+
   def get_container_hostname(container)
     # '{{json .NetworkSettings.Networks}}' useful in debug
     # returns all aliases in a Go array like [foo bar baz], so turn into Ruby array to inspect
@@ -362,15 +371,11 @@ module SpecHelpers
   # Puppetserver Helpers
   ######################################################################
 
+  # @deprecated - remove method once all callers are updated
   # Waits for the container healthcheck to return 'healthy'
   # See also: `wait_for_puppetserver`
   def wait_on_puppetserver_status(seconds = 180, service_name = 'puppet')
-    # puppetserver has a healthcheck, we can let that deal with timeouts
-    return retry_block_up_to_timeout(seconds) do
-      status = get_container_status(get_service_container(service_name))
-      (status == 'healthy' || status == "'healthy'") ? 'healthy' :
-        raise("puppetserver stuck in #{status}")
-    end
+    wait_on_service_health(service_name, seconds)
   end
 
   def get_puppetserver_status()

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -19,7 +19,7 @@ shared_examples 'a running pupperware cluster' do
   end
 
   it 'should start puppetserver' do
-    expect(wait_on_puppetserver_status()).to match(/\'?healthy\'?/)
+    expect(wait_on_service_health('puppet')).to eq('healthy')
   end
 
   it 'should start puppetdb' do

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -23,7 +23,7 @@ shared_examples 'a running pupperware cluster' do
   end
 
   it 'should start puppetdb' do
-    expect(wait_on_puppetdb_status()).to eq('running')
+    expect(wait_on_service_health('puppetdb', 240)).to eq('healthy')
   end
 
   it 'should include postgres extensions' do


### PR DESCRIPTION
 - Instead of creating specific methods for each service, make a helper that
   generically takes a service and uses its HEALTHCHECK

 - When wait_on_puppetserver_status is removed from other repos, it can
   be removed as a helper from this repository