### PR TITLE
(maint) Use Hadolint container on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,48 +20,8 @@ steps:
 - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
   clean: true  # whether to fetch clean each time
 - powershell: |
-    $line = '=' * 80
-    Write-Host "$line`nWindows`n$line`n"
-    Get-ComputerInfo |
-      select WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer |
-      Out-String |
-      Write-Host
-    #
-    # Azure
-    #
-    $assetTag = Get-WmiObject -class Win32_SystemEnclosure -namespace root\CIMV2 |
-      Select -ExpandProperty SMBIOSAssetTag
-
-    # only Azure VMs have this hard-coded DMI value
-    if ($assetTag -eq '7783-7084-3265-9085-8269-3286-77')
-    {
-      Write-Host "`n`n$line`nAzure`n$line`n"
-      Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
-        ConvertTo-Json -Depth 10 |
-        Write-Host
-    }
-    #
-    # Docker
-    #
-    Write-Host "`n`n$line`nDocker`n$line`n"
-    docker version
-    docker images
-    docker info
-    docker-compose version
-    sc.exe qc docker
-    #
-    # Ruby
-    #
-    Write-Host "`n`n$line`nRuby`n$line`n"
-    ruby --version
-    gem --version
-    gem env
-    bundle --version
-    #
-    # Environment
-    #
-    Write-Host "`n`n$line`nEnvironment`n$line`n"
-    Get-ChildItem Env: | % { Write-Host "$($_.Key): $($_.Value)"  }
+    . gem/ci/build.ps1
+    Write-HostDiagnostics
   displayName: Diagnostic Host Information
   name: hostinfo
 


### PR DESCRIPTION
 - Previously the specs assumed Hadolint was installed locally, which
   is an inflexible solution to the linting on Windows problem

	 Instead, pull hadolint/hadolint:latest during suite start-up and
   use stdin redirection to push the Dockerfile over stdin