### PR TITLE
(maint) Refactor shared build.ps1 / spec helpers

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --format RspecJunitFormatter
 --out TEST-rspec.xml
 --format documentation
+--fail-fast

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,16 +52,8 @@ steps:
   condition: always()
 
 - powershell: |
-    Write-Host 'Pruning containers'
-    docker container prune --force
-    Write-Host 'Pruning images'
-    docker image prune --filter "dangling=true" --force
-    Write-Host "Pruning Volumes"
-    docker volume prune
-    Write-Host "Pruning Networks"
-    docker network prune
-    Write-Host "Cleaning up temporary volume: $ENV:VOLUME_ROOT"
-    Remove-Item $ENV:VOLUME_ROOT -Force -Recurse -ErrorAction Continue
+    . gem/ci/build.ps1
+    Clear-ContainerBuilds
   displayName: Container Cleanup
   timeoutInMinutes: 3
   condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,8 @@ steps:
   name: test_prepare
 
 - powershell: |
-    Write-Host 'Executing Pupperware specs'
-    bundle exec rspec --version
-    bundle exec rspec spec --fail-fast
+    . gem/ci/build.ps1
+    Invoke-ContainerTest -Specs spec
   displayName: Test pupperware
   name: test_pupperware
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ steps:
 
 - powershell: |
     . gem/ci/build.ps1
-    Clear-ContainerBuilds
-  displayName: Container Cleanup
+    Clear-BuildState
+  displayName: Build Cleanup
   timeoutInMinutes: 3
   condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,6 @@ steps:
   name: test_prepare
 
 - powershell: |
-    Write-Host 'Writing compose config to disk'
-    $content = @"
-    VOLUME_ROOT=$ENV:VOLUME_ROOT
-    "@
-    $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-    [System.IO.File]::WriteAllLines(".env", $content, $Utf8NoBomEncoding)
-    Get-Content -Path '.env'
     Write-Host 'Executing Pupperware specs'
     bundle exec rspec --version
     bundle exec rspec spec --fail-fast

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,12 @@ steps:
 
 - powershell: |
     bundle install --with test --path '.bundle/gems'
-    # set an Azure variable for temp volumes root
-    $tempVolumeRoot = Join-Path -Path $ENV:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
-    Write-Host "##vso[task.setvariable variable=VOLUME_ROOT]$tempVolumeRoot"
+  displayName: Fetch Dependencies
+  name: fetch_deps
+
+- powershell: |
+    . gem/ci/build.ps1
+    Initialize-TestEnv
   displayName: Prepare Test Environment
   name: test_prepare
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,15 +39,15 @@ steps:
 - powershell: |
     . gem/ci/build.ps1
     Invoke-ContainerTest -Specs spec
-  displayName: Test pupperware
-  name: test_pupperware
+  displayName: Test $(COMPOSE_PROJECT_NAME)
+  name: test
 
 - task: PublishTestResults@2
-  displayName: Publish pupperware test results
+  displayName: Publish $(COMPOSE_PROJECT_NAME) test results
   inputs:
     testResultsFormat: 'JUnit'
     testResultsFiles: 'TEST-rspec.xml'
-    testRunTitle: pupperware Test Results
+    testRunTitle: $(COMPOSE_PROJECT_NAME) Test Results
   condition: always()
 
 - powershell: |

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -65,7 +65,7 @@ function Build-Container(
         $docker_args += '--pull'
     }
 
-    Write-Output "docker build $docker_args $Context"
+    Write-Host "docker build $docker_args $Context"
 
     docker build $docker_args $Context
 }

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -58,7 +58,7 @@ function Build-Container(
         '--build-arg', "vcs_ref=$Vcs_ref",
         '--build-arg', "build_date=$build_date",
         '--build-arg', "namespace=$Namespace",
-        '--file', "$Dockerfile",
+        '--file', $Dockerfile,
         '--tag', "$Namespace/${Name}:$Version"
     ) + $AdditionalOptions
 
@@ -89,8 +89,8 @@ function Invoke-ContainerTest(
     # NOTE our shared `docker_compose` Ruby method assumes the
     # docker-compose.yml files are in the current working directory,
     # so we assume they're in the same directory as the specdir
-    Push-Location (Split-Path "$Specs")
-    $specdir = Split-Path -Leaf "$Specs"
+    Push-Location (Split-Path $Specs)
+    $specdir = Split-Path -Leaf $Specs
 
     if ($Name -ne $null)
     {
@@ -137,7 +137,7 @@ function Clear-ComposeLeftOvers
 function Remove-ContainerVolumeRoot
 {
     # delete directory if ENV variable is defined and directory actually exists
-    if (($ENV:VOLUME_ROOT) -and (Test-Path "$ENV:VOLUME_ROOT")) {
+    if (($ENV:VOLUME_ROOT) -and (Test-Path $ENV:VOLUME_ROOT)) {
         Write-Host "Cleaning up temporary volume: $ENV:VOLUME_ROOT"
         Remove-Item $ENV:VOLUME_ROOT -Force -Recurse -ErrorAction Continue
     }

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -49,7 +49,8 @@ function Build-Container(
     $Context = "docker/$Name",
     $Version = (Get-ContainerVersion),
     $Vcs_ref = $(git rev-parse HEAD),
-    $Pull = $true)
+    $Pull = $true,
+    $AdditionalOptions = @())
 {
     $build_date = (Get-Date).ToUniversalTime().ToString('o')
     $docker_args = @(
@@ -59,7 +60,7 @@ function Build-Container(
         '--build-arg', "namespace=$Namespace",
         '--file', "$Dockerfile",
         '--tag', "$Namespace/${Name}:$Version"
-    )
+    ) + $AdditionalOptions
 
     if ($Pull) {
         $docker_args += '--pull'

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -46,7 +46,9 @@ function Build-Container(
     $Name,
     $Namespace = 'puppet',
     $Dockerfile = "docker/$Name/Dockerfile",
-    $Context = "docker/$Name",
+    # Context alias set for backward compatibility, but deprecated
+    [Alias('Context')]
+    $PathOrUri = "docker/$Name",
     $Version = (Get-ContainerVersion),
     $Vcs_ref = $(git rev-parse HEAD),
     $Pull = $true,
@@ -66,9 +68,10 @@ function Build-Container(
         $docker_args += '--pull'
     }
 
-    Write-Host "docker build $docker_args $Context"
+    Write-Host "docker build $docker_args $PathOrUri"
 
-    docker build $docker_args $Context
+    # https://docs.docker.com/engine/reference/commandline/build/
+    docker build $docker_args $PathOrUri
 }
 
 # set an Azure variable for temp volumes root

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -17,7 +17,9 @@ function Get-ContainerVersion
         git fetch origin 'refs/tags/*:refs/tags/*'
     }
 
-    (git describe) -replace '-.*', ''
+    $gitver = git describe
+    if ($LASTEXITCODE -ne 0) { return '0.0.0' }
+    $gitver -replace '-.*', ''
 }
 
 # only need to specify -Name or -Path when calling
@@ -89,8 +91,11 @@ function Invoke-ContainerTest(
     Push-Location (Split-Path "$Specs")
     $specdir = Split-Path -Leaf "$Specs"
 
-    $ENV:PUPPET_TEST_DOCKER_IMAGE = "$Namespace/${Name}:$Version"
-    Write-Host "Testing against image: ${ENV:PUPPET_TEST_DOCKER_IMAGE}"
+    if ($Name -ne $null)
+    {
+        $ENV:PUPPET_TEST_DOCKER_IMAGE = "$Namespace/${Name}:$Version"
+        Write-Host "Testing against image: ${ENV:PUPPET_TEST_DOCKER_IMAGE}"
+    }
     bundle exec rspec --version
 
     Write-Host "bundle exec rspec --options $Options $specdir"

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -288,7 +288,7 @@ module SpecHelpers
   end
 
   # @deprecated - remove method once all callers are updated
-  def wait_on_puppetdb_status(seconds = 240)
+  def wait_on_puppetdb_status(seconds = 300)
     wait_on_service_health('puppetdb', seconds)
   end
 


### PR DESCRIPTION
- Tweak build.ps1 so that it can be used in this repo and refactor the local `azure-pipelines.yml` accordingly.
- Also update the spec helpers so that these changes can be integrated into puppetserver
- Given the VOLUME_ROOT env var is defined against the host for the entire run, it's already consumable by docker-compose.yml.
- Rework the Clean-ContainerBuilds code so that it works for individual container builds like puppetdb, puppetserver, r10k -- but also for this repo and others that don't build containers
- Make sure to use Write-Host rather than Write-Output since stdout is what matters here
- Adjust Get-ContainerVersion to return 0.0.0 when no git tags are available (since pupperware repo doesn't need a version)
- When no container name is specified for running tests, don't set the environment variable for the image name
- Since we care about stdout and not pipeline output, use Write-Host since its appropriate for a CI pipeline
- Callers of the Clear-ContainerBuilds helper should now use Clear-BuildState, which performs 4 distinct operations now:
 - Clear-ComposeLeftOvers - removes unused containers, networks and volumes
  - Remove-ContainerVolumeRoot - deletes ENV:VOLUME_ROOT recursively
  - Clear-ContainerBuilds - removes images based on the namespace/name
  - Clear-DanglingImages - prunes any dangling images

- Clear-ContainerBuilds will keep the same signature and will continue to remove images in the same way it did previously, BUT all callsites should be updated to use Clear-BuildState instead (which takes same arguments)
- Add -AddtionalOptions to Build-Container  …
    - Necessary to support arbitrary switches, for instance with puppetserver which wishes to pass @('--memory', '4g')
- Define 'pupperware' once and use the variable (this makes it easier to copy / paste the azure-pipelines.yml and minimally change it)
- Remove unnecessary PowerShell quoting
- Use the Docker terminology for the parameter name that accepts PATH | URL by changing "Context" to "PathOrUri" (Adds an alias for backwards compatibility until all calling repos can be updated)
- Update PDB wait time to 5 minutes from 4 -- Even though this method is deprecated, not all callers have been updated with a different wait mechanism just yet. There have been some recent failures which look to be the result of
   PDB not entering a 'healthy' state just yet due to still making
   changes to Postgres / running db migrations / etc.
- spec_helper argument standardization
   Really, we should be using named arguments because it's easier to support additional arguments in a backwards compatible way. But that will require further changes. For now, at least fix a few issues with missing arguments, etc