### PR TITLE
(maint) Add two helper methods for pe-bolt-server

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -368,9 +368,8 @@ module SpecHelpers
   # PE Bolt Server Helpers
   ######################################################################
 
-  def curl_job_number(job_number)
+  def curl_job_number(job_number, timeout = 30)
     #Wait for 30 seconds for the task to run
-    timeout = 30
     puts "Waiting for the task to run..."
     return retry_block_up_to_timeout(timeout) do
       output = curl('localhost', 443, "api/jobs/#{job_number}").body
@@ -381,14 +380,14 @@ module SpecHelpers
     return output
   end
 
-  def curl_console_task()
+  def curl_console_task(target_nodes)
     uri = URI.parse("https://localhost:443/api/tasks/create")
     request = Net::HTTP::Post.new(uri)
     request.content_type = "application/json"
     request["X-Authentication"] = @rbac_token
     request.body = JSON.dump({
                                "nodes" => [
-                                 "test_sshd.test"
+                                 target_nodes
                                ],
                                "targets" => [
                                  {
@@ -396,7 +395,7 @@ module SpecHelpers
                                    "user" => "root",
                                    "password" => "root",
                                    "hostnames" => [
-                                     "test_sshd.test"
+                                     target_nodes
                                    ]
                                  }
                                ],

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -368,7 +368,7 @@ module SpecHelpers
   # PE Bolt Server Helpers
   ######################################################################
 
-  def curl_job_number(job_number, timeout = 30)
+  def curl_job_number(job_number:, timeout: 30)
     #Wait for 30 seconds for the task to run
     puts "Waiting for the task to run..."
     return retry_block_up_to_timeout(timeout) do
@@ -380,7 +380,7 @@ module SpecHelpers
     return output
   end
 
-  def curl_console_task(target_nodes)
+  def curl_console_task(target_nodes:)
     uri = URI.parse("https://localhost:443/api/tasks/create")
     request = Net::HTTP::Post.new(uri)
     request.content_type = "application/json"

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -365,6 +365,66 @@ module SpecHelpers
   end
 
   ######################################################################
+  # PE Bolt Server Helpers
+  ######################################################################
+
+  def curl_job_number(job_number)
+    #Wait for 30 seconds for the task to run
+    timeout = 30
+    puts "Waiting for the task to run..."
+    return retry_block_up_to_timeout(timeout) do
+      output = curl('localhost', 443, "api/jobs/#{job_number}").body
+      puts output
+      output !~ /running/ ? output :
+        raise("Job was still running after #{timeout} seconds")
+    end
+    return output
+  end
+
+  def curl_console_task()
+    uri = URI.parse("https://localhost:443/api/tasks/create")
+    request = Net::HTTP::Post.new(uri)
+    request.content_type = "application/json"
+    request["X-Authentication"] = @rbac_token
+    request.body = JSON.dump({
+                               "nodes" => [
+                                 "test_sshd.test"
+                               ],
+                               "targets" => [
+                                 {
+                                   "transport" => "ssh",
+                                   "user" => "root",
+                                   "password" => "root",
+                                   "hostnames" => [
+                                     "test_sshd.test"
+                                   ]
+                                 }
+                               ],
+                               "task" => "service",
+                               "params" => [
+                                 {
+                                   "name" => "action",
+                                   "value" => "status"
+                                 },
+                                 {
+                                   "name" => "name",
+                                   "value" => "sshd"
+                                 }
+                               ]
+                             })
+    req_options = {
+      use_ssl: uri.scheme == "https",
+      verify_mode: OpenSSL::SSL::VERIFY_NONE,
+    }
+
+    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+      http.request(request)
+    end
+
+    return response.body
+  end
+
+  ######################################################################
   # Puppetserver Helpers
   ######################################################################
 


### PR DESCRIPTION
curl_console_task: This will hit the console endpoint that will generate
a job that will run a task over SSH. The task needs to be in the puppetserver's
module path in order for this to work. pe-bolt-server's docker directory has
an example of this.

curl_job_number: curls the console for a job until the job is no longer running.