### PR TITLE
(MAINT) Don't redirect in exec command

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -500,7 +500,7 @@ module SpecHelpers
   def wait_for_pxp_agent_to_connect(service: 'puppet-agent', timeout: 180)
     puts "Waiting for the puppet-agent's pxp-agent to connect to the pe-orchestration-service"
     return retry_block_up_to_timeout(timeout) do
-      command = "cat /var/log/puppetlabs/pxp-agent/pxp-agent.log 2> /dev/null"
+      command = "cat /var/log/puppetlabs/pxp-agent/pxp-agent.log"
       output = docker_compose("exec -T #{service} #{command}")
       raise("pxp-agent has not connected after #{timeout} seconds") if !output[:stdout].include?('Starting the monitor task')
     end


### PR DESCRIPTION
Using pipes, redirects in a `docker-compose exec <COMMAND>` invocation
is problematic as the pipe/redirect will not be considered part of the
COMMAND and thus won't run in the container, but instead on the host
system.

In this case, just remove the redirect and let the `No such file or
directory` message appear in the test output, since this change was
simply for quieting down errors/warnings in the test output.