### PR TITLE
(maint) Improve container cleanup / shutdown and add to diagnostic output

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -123,6 +123,7 @@ function Clear-BuildState(
     Remove-ContainerVolumeRoot
     Clear-ContainerBuilds @PSBoundParameters
     Clear-DanglingImages
+    Write-DockerResourceInformation
 }
 
 function Clear-ComposeLeftOvers
@@ -204,6 +205,25 @@ function Clear-DanglingImages
 {
     Write-Host "`nPruning Dangling Images"
     docker image prune --filter "dangling=true" --force
+}
+
+function Write-DockerResourceInformation()
+{
+    $line = '=' * 80
+
+    Write-Host "`nExisting Docker Resources"
+
+    Write-Host "$line`nContainers`n$line`n"
+    docker container ps --all
+
+    Write-Host "$line`nImages`n$line`n"
+    docker image ls
+
+    Write-Host "$line`nNetworks`n$line`n"
+    docker network ls
+
+    Write-Host "$line`nVolumes`n$line`n"
+    docker volume ls
 }
 
 function Write-HostDiagnostics()

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -96,6 +96,13 @@ module SpecHelpers
                                 #{command_and_args}")
   end
 
+  def docker_compose_up()
+    docker_compose('up --detach')
+    docker_compose('images')
+    # TODO: use --all when docker-compose fixes https://github.com/docker/compose/issues/6579
+    docker_compose('ps')
+  end
+
   # Windows requires directories to exist prior, whereas Linux will create them
   def create_host_volume_targets(root, volumes)
     return unless IS_WINDOWS

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -103,6 +103,15 @@ module SpecHelpers
     docker_compose('ps')
   end
 
+  def docker_compose_down()
+    docker_compose('down --volumes')
+    STDOUT.puts("Running containers in compose:")
+    # TODO: use --all when docker-compose fixes https://github.com/docker/compose/issues/6579
+    docker_compose('ps')
+    STDOUT.puts("Running containers in system:")
+    run_command('docker ps --all')
+  end
+
   # Windows requires directories to exist prior, whereas Linux will create them
   def create_host_volume_targets(root, volumes)
     return unless IS_WINDOWS
@@ -160,7 +169,7 @@ module SpecHelpers
       teardown_container(id)
     end
     # still needed to remove network / provide failsafe
-    docker_compose('down --volumes')
+    docker_compose_down()
   end
 
   ######################################################################

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -215,6 +215,11 @@ module SpecHelpers
     inspect_container(container, '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
   end
 
+  # this only works when a container has a single network
+  def get_container_network(container)
+    inspect_container(container, '{{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}')
+  end
+
   def emit_log(container)
     container_name = get_container_name(container)
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
@@ -224,6 +229,8 @@ module SpecHelpers
 
   def teardown_container(container)
     STDOUT.puts("Tearing down test container")
+    network_id = get_container_network(container)
+    run_command("docker network disconnect -f #{network_id} #{container}")
     run_command("docker container rm --force #{container}")
   end
 

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -18,7 +18,7 @@ describe 'The docker-compose file works' do
     # since search domains are not appended to /etc/resolv.conf
     @test_agent = "puppet_test#{Random.rand(1000)}.#{ENV['DOMAIN'] || 'internal'}"
     @timestamps = []
-    status = run_command('docker-compose --no-ansi version')[:status]
+    status = docker_compose('version')[:status]
     if status.exitstatus != 0
       fail "`docker-compose` must be installed and available in your PATH"
     end
@@ -26,7 +26,7 @@ describe 'The docker-compose file works' do
     # LCOW requires directories to exist
     create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
     # ensure all containers are latest versions
-    run_command('docker-compose --no-ansi pull --quiet')
+    docker_compose('pull --quiet')
   end
 
   after(:all) do
@@ -47,7 +47,8 @@ describe 'The docker-compose file works' do
     # https://github.com/docker/for-win/issues/629
     it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
       expect(get_containers()).not_to be_empty
-      run_command('docker-compose --no-ansi down')
+      # don't use shared helper as it removes volumes
+      docker_compose('down')
       expect(get_containers()).to be_empty
     end
 

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -2,7 +2,7 @@ shared_context "running_cluster", :shared_context => :metadata do
   include Pupperware::SpecHelpers
 
   before(:each) do
-    run_command('docker-compose --no-ansi up --detach')
+    docker_compose_up()
     wait_on_postgres_db('puppetdb')
   end
 end


### PR DESCRIPTION
 - In rare circumstances, shutting down containers doesn't work because
   they are still attached to networks. Error messages may appear like:

   Removing network pupperware-commercial
   ERROR: error while removing network: network pupperware-commercial id 007d116f17a16dc732171d02746b65d764008948d82f83133b1e7857edb91789 has active endpoints

 - As part of shutting down containers, forcibly disconnect them from
   their network first.

Additionally add to the output during CI / spec runs --


#### 0c507e6 changes teardown output to look like this now:

```
Tearing down test cluster
25b715592c15381f9d27a9ea0630adaaf784685484cd5895379ef2125f7929e6
da17335feecb4c6080edc6876bf7eda770ee6184ec3d85bdac435eeaeb9a1943
9afb28e7a92c2fae172a7165e07dd270df0e1f44ff0ceeab25664a8b35553084
Retrieved running container ids:
25b715592c15381f9d27a9ea0630adaaf784685484cd5895379ef2125f7929e6
da17335feecb4c6080edc6876bf7eda770ee6184ec3d85bdac435eeaeb9a1943
9afb28e7a92c2fae172a7165e07dd270df0e1f44ff0ceeab25664a8b35553084
Tearing down test container
64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
queried {{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}} of 25b715592c15381f9d27a9ea0630adaaf784685484cd5895379ef2125f7929e6: 64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
25b715592c15381f9d27a9ea0630adaaf784685484cd5895379ef2125f7929e6
Tearing down test container
64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
queried {{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}} of da17335feecb4c6080edc6876bf7eda770ee6184ec3d85bdac435eeaeb9a1943: 64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
da17335feecb4c6080edc6876bf7eda770ee6184ec3d85bdac435eeaeb9a1943
Tearing down test container
64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
queried {{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}} of 9afb28e7a92c2fae172a7165e07dd270df0e1f44ff0ceeab25664a8b35553084: 64b5cd77ff7602f05401a402c02cefef83836a370aec7b0be4b904d2aa3154a8
9afb28e7a92c2fae172a7165e07dd270df0e1f44ff0ceeab25664a8b35553084
Removing network pupperware_default
```

#### 52da556 adds the following new output with the `docker_compose_up` helper:

```
      Container             Repository         Tag       Image Id      Size 
----------------------------------------------------------------------------
pupperware_postgres_1   postgres              9.6      f5548544c480   245 MB
pupperware_puppet_1     puppet/puppetserver   latest   562e5fa0fa44   602 MB
pupperware_puppetdb_1   puppet/puppetdb       latest   eb9c2816291d   279 MB
The system cannot find the path specified.
        Name                       Command                       State                                Ports                      
---------------------------------------------------------------------------------------------------------------------------------
pupperware_postgres_1   docker-entrypoint.sh postgres    Up                      5432/tcp                                        
pupperware_puppet_1     dumb-init /docker-entrypoi ...   Up (health: starting)   0.0.0.0:8140->8140/tcp                          
pupperware_puppetdb_1   /usr/bin/tini -g -- /docke ...   Up (health: starting)   0.0.0.0:51958->8080/tcp, 0.0.0.0:51957->8081/tcp
```

#### 70b6a1a adds the following output during teardown (which happens at both the beginning and end of some spec suites):

```
Running containers in compose:
The system cannot find the path specified.
Name   Command   State   Ports
------------------------------
Running containers in system:
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```

#### 927cd5c adds output in Azure like:

```
Existing Docker Resources
================================================================================
Containers
================================================================================

CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
================================================================================
Images
================================================================================

REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
puppet/puppetdb                  latest              eb9c2816291d        About an hour ago   292MB
puppet/puppetdb                  6.5.0               5807c1912592        2 hours ago         294MB
puppet/puppetserver              latest              562e5fa0fa44        3 hours ago         631MB
puppet/puppetserver              6.5.0               535bad0689a5        4 hours ago         634MB
puppet/puppetserver-standalone   6.5.0               a314452653bb        4 hours ago         631MB
puppet/puppet-agent-ubuntu       latest              210657e5e6a0        5 hours ago         303MB
clojure                          openjdk-8-lein      c1afc2916269        18 hours ago        551MB
puppet/puppetdb                  6.4.0               7ff6da0425d9        27 hours ago        294MB
openjdk                          8-jre-slim-buster   624624f99e2f        36 hours ago        197MB
postgres                         9.6                 f5548544c480        44 hours ago        257MB
puppet/r10k                      3.2.1               4816e952c7c2        46 hours ago        177MB
puppet/puppet-runtime            201908071           72136cd4735b        47 hours ago        577MB
puppet/puppet-agent-ubuntu       6.7.2               9c83441a7311        47 hours ago        304MB
puppet/puppet-agent              6.7.2               9c83441a7311        47 hours ago        304MB
puppet/puppet-runtime            201908061           b95576b5cf8b        8 days ago          577MB
puppet/puppet-runtime            201907260           ad64a605062b        9 days ago          577MB
ubuntu                           16.04               5e13f8dd4c1a        3 weeks ago         136MB
hadolint/hadolint                latest              f50f63c73c84        3 weeks ago         3.32MB
postgres                         9.6.13              d86a7033d301        2 months ago        257MB
clojure                          lein-alpine         6db0a6c987f3        3 months ago        153MB
openjdk                          8-jre-alpine        f7a292bbb70c        3 months ago        89.7MB
alpine                           3.9                 055936d39205        3 months ago        6.28MB
centos                           7                   9f38484d220f        5 months ago        225MB
alpine                           3.8                 dac705114996        5 months ago        5.13MB
================================================================================
Networks
================================================================================

NETWORK ID          NAME                DRIVER              SCOPE
a8d8a1c36e16        nat                 nat                 local
8e5f92d6cee6        none                null                local
================================================================================
Volumes
================================================================================

DRIVER              VOLUME NAME
local               0ea4ec8e4d2b111190a4b0926ac4946271dc7b2f4dd2c78c7528fec8e193619b
local               2f142da875f8635f3bdde7098dae46e8128877ffadac21b8c069667d07b0a4a1
local               3eb2ac0323008c7111aecd0e06f2bf7845ebaae5ada16b839b1be60c00b8dee3
local               3f2ffa25c90e0b9838aeeb506e86dded2a77fc587646bb811eeec251b9984f11
local               4a920e1dacb823e65f2eea439433530ae4230dfb1d04c3b1fd45874f4acde026
local               5ad979c26526664277a063b122713460dc70b3baf16569fd1f5ec0da0ba960b0
local               5be4b9fef4fbb805338a227f775164a56222250718be0974a18f8c0f6cad2851
local               6b83c8a807b7408b67a6f7cb1ac89ccf3baedcdcf0601172c49f60370ee2c971
local               8d9a49c0e55a5533c73cf81dbf65bc1c777c8059d79ea30f2e3a54716c40908d
local               8ee2f10f79ca9eeb1d49be17f36a04556a7215888c7f4ed939ac534a7b31e11e
local               9aa54af53e37c603de4c6211e4f11b5c546d450d24ca7bf2f1c9e6ec88819c16
local               9dfa32c46d5752ea9fd4f797d73845bfaf3122165b1918581416f8da08573d50
local               9e736ed6590bbf41f2eaa2f9ed3823779a36152de91ab874c2c1ce486b9d47a5
local               54bd1e64fa282c646b180c16baab304dcbd6a0551f19525a304757cb2cac73e7
local               58af97fce0d7599caf69c2580e3a5dbd9d48c000ad0900e95c87f41079a24169
local               79bbe3c0bc1add2574c77c99500fa732d4fd7918dce374366b66908561b92ef8
local               86e47d1b66e47c49ac3c3444325c2c3df2394db536c42536f238ae111a5b6964
local               93e0c672b0ed2a6dd7c4861587e6f8553b9e05107d91366041cd56787c327547
local               333f0527d7d1466b69b7ae9e359f54316cdcab0b0d638692887cb086646c3597
local               424c9964aca075891695aa989554f7d67a12fc4352e55fceebb22a527e3cbddd
local               946a932b640d5b0e805382429ae71b28b6b6c0f828ce21df91639e8718299dd5
local               994dab0c3a7221539d607ec6a9f568d43f70a4f5a84e714fd76db4220db9b49f
local               2333df6dff9a5f37c87af41492a404f98a26e9ee6002e8aa744b43ea3fc947d7
local               3010fb935f08416e95a87e1ea18170eecdd197d06fbb096b5a2e6221105222a3
local               3935f907669390e887c3639c3143ebb605f2dce84de8be0356071ed89dd1ea44
local               3982c5971255edb12b0138b7a405f37fd2b83f04a26d3bbb01fc283895057675
local               4017e8ddcbbd243cbc077a651c914527364291ffde4076deb4397f1806f2e747
local               5220b2b1b28f733d352d1d1abd3b2580870d6a0b5060c482df508c0c6dd6d696
local               18300ee859be4b0bf0007590f2752ac96ed7f21aa95a39b5136617a1e3103399
local               51049f497b1de5d8bfb4001607616381147cba9b8b1dd4b96885fa31d8e88cfc
local               263100af47a6834b15401f73079e06b9321f355360bdbf3217e107802a9e51ce
local               385339c55b8d1f03b4ccbf6abd301ef7884bbb04f40515a2f842f7b04cb3628a
local               487759b8b968263f9400e418128e16076688cde7cccb14a70bac3613164d8066
local               671095f4a5f7d0def1d0b1362d8712e5c48c002c548529d9ee3924fe533faed1
local               3383897ed412ef118e7b5e3299cea0401d5180a5254185dc58f3c69106919c50
local               37083076fd7809adafeef08305e7fb08a3d5373459a5e1b718503af2284669cb
local               53028562ee5d29b902742a004e03259e5d9c3cbb64a6fa4c18a9b34ea65cd96e
local               a90f77131883eb0a77d5f0f5e86b63d3dac01c993727b360b97aba88074a476e
local               b3f658138ff289b71c1a5f020861f1cdca77a3dce960a6006f31e9eba3a9045e
local               b05f526adada76460cd4acd1c49d5d290c21b01a632296a1bf597ab64ca3c5da
local               b8bda74cdc8a126ccae4d16031bb2e8764d0bb6068cd7ceaa3b44dd1031ff293
local               b520f0d7586b34935b32844410fc59eba203c61f997bdfae59588854088fae2b
local               ba62ccd22ef74ee1174aa84f796f128c69e7d1ba3cbf3d2ccd4d5bd5ff230565
local               bcadcfce1442423800e2b609d0db5593fff2638e6408fae8036beb53db36e44b
local               c2d505da7059fb85c43927966e9b2eb6a97be63ff1d7cb8c2f50736c2fac2c64
local               c77eb6c342f57f25a245209eefa7d6f81d8a145c2cea1b1dde830842525e6340
local               cb4393af6beafb34f76d8f84b0d9fefb8ce1d4240a83318a6edd73d844a888f6
local               cf20ea7cfb6cd2d52abebe869219a0a718400786a21df00fea25f552c325a1fa
local               d3c5069ccc6f984fd5a0e52a65265f01adf43d856f1d0669824ba1c644ce6a65
local               d598f20b1d30220c03dcd083bc2d90ea10b199db142376357e9172f95589dd78
local               db0c243a25e1d32f41ad470ff95c590ff0bf9d45cdcb03a2ea568ed1d1c9013d
local               db8046b8735bcbb2d9c35e2d935899aaa2db3c84883646f214b48b0f135a6b4b
local               dd9c607cb43049af92272612c14a0c3771f60cafec23a7b2854b49ed7b3ca74d
local               e4d796982862433329815010897a5c2948b091be15e5b0c977497bc611918d09
local               e7a74153282e276d85b4d5b1502a778b72c1b870927a6f62eaabae242f760881
local               e9783f369660b2e4821e730fa2078e84717624e0ce44d96233ac19618261dae4
local               f6bf0aabc4ef404d20f0f144bcc377a8738b76c96e9935990ef6b060a5538e98
local               f449229cc0dac90395d742909c3f17b655bd88f027975ab81c71e91f428d73c4
local               fa4e1fa23c591c9027bb7bf55bc62bac2e759c395b4c690b17620b142cc8ba61
local               fc0b661012e9de30d78145434509c2dc57bee905ab0257f83874f9a61dfb8ef5
```