### PR TITLE
(maint) switch compose TLD to .example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once you have Docker Compose installed, you can start the stack on Linux or macO
 
 The value of `DNS_ALT_NAMES` must list all the names, as a comma-separated
 list, under which the Puppet server in the stack can be reached from
-agents. It will have `puppet` and `puppet.internal` prepended to it as that
+agents. It will have `puppet` and `puppet.example` prepended to it as that
 name is used by PuppetDB to communicate with the Puppet server. The value of
 `DNS_ALT_NAMES` only has an effect the first time you start the stack, as it
 is placed into the server's SSL certificate. If you need to change it after
@@ -39,7 +39,7 @@ that, you will need to properly revoke the server's certificate and restart
 the stack with the changed `DNS_ALT_NAMES` value.
 
 Optionally, you may also provide a desired `DOMAIN` value, other than default
-value of `internal` to further define how the service hosts are named. It is
+value of `example` to further define how the service hosts are named. It is
 not necessary to change `DNS_ALT_NAMES` as the default value already takes into
 account any custom domain.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,30 +2,30 @@ version: '3'
 
 services:
   puppet:
-    hostname: puppet.${DOMAIN:-internal}
+    hostname: puppet.${DOMAIN:-example}
     image: puppet/puppetserver
     ports:
       - 8140:8140
     environment:
       # necessary to set certname and server in puppet.conf, required by
       # puppetserver ca cli application
-      - PUPPETSERVER_HOSTNAME=puppet.${DOMAIN:-internal}
+      - PUPPETSERVER_HOSTNAME=puppet.${DOMAIN:-example}
       # DNS_ALT_NAMES must be set before starting the stack the first time,
       # and must list all the names under which the puppetserver can be
-      # reached. 'puppet.${DOMAIN:-internal}' must be one of them, otherwise puppetdb won't be
+      # reached. 'puppet.${DOMAIN:-example}' must be one of them, otherwise puppetdb won't be
       # able to get a cert. Add other names as a comma-separated list
-      - DNS_ALT_NAMES=puppet,puppet.${DOMAIN:-internal},${DNS_ALT_NAMES:-}
+      - DNS_ALT_NAMES=puppet,puppet.${DOMAIN:-example},${DNS_ALT_NAMES:-}
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
-      - PUPPETDB_SERVER_URLS=https://puppetdb.${DOMAIN:-internal}:8081
+      - PUPPETDB_SERVER_URLS=https://puppetdb.${DOMAIN:-example}:8081
     volumes:
       - ${VOLUME_ROOT:-.}/volumes/code:/etc/puppetlabs/code/
       - ${VOLUME_ROOT:-.}/volumes/puppet:/etc/puppetlabs/puppet/
       - ${VOLUME_ROOT:-.}/volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
-    dns_search: ${DOMAIN:-internal}
+    dns_search: ${DOMAIN:-example}
     networks:
       default:
         aliases:
-         - puppet.${DOMAIN:-internal}
+         - puppet.${DOMAIN:-example}
 
   postgres:
     image: postgres:9.6
@@ -38,20 +38,20 @@ services:
     volumes:
       - ${VOLUME_ROOT:-.}/volumes/puppetdb-postgres/data:/var/lib/postgresql/data
       - ./postgres-custom:/docker-entrypoint-initdb.d
-    dns_search: ${DOMAIN:-internal}
+    dns_search: ${DOMAIN:-example}
     networks:
       default:
         aliases:
-         - postgres.${DOMAIN:-internal}
+         - postgres.${DOMAIN:-example}
 
   puppetdb:
-    hostname: puppetdb.${DOMAIN:-internal}
+    hostname: puppetdb.${DOMAIN:-example}
     image: puppet/puppetdb
     environment:
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
       # This name is an FQDN so the short name puppet doesn't collide outside compose network
-      - PUPPETSERVER_HOSTNAME=puppet.${DOMAIN:-internal}
-      - PUPPETDB_POSTGRES_HOSTNAME=postgres.${DOMAIN:-internal}
+      - PUPPETSERVER_HOSTNAME=puppet.${DOMAIN:-example}
+      - PUPPETDB_POSTGRES_HOSTNAME=postgres.${DOMAIN:-example}
       - PUPPETDB_PASSWORD=puppetdb
       - PUPPETDB_USER=puppetdb
     ports:
@@ -62,8 +62,8 @@ services:
       - puppet
     volumes:
       - ${VOLUME_ROOT:-.}/volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
-    dns_search: ${DOMAIN:-internal}
+    dns_search: ${DOMAIN:-example}
     networks:
       default:
         aliases:
-         - puppetdb.${DOMAIN:-internal}
+         - puppetdb.${DOMAIN:-example}

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -14,9 +14,9 @@ describe 'The docker-compose file works' do
   ]
 
   before(:all) do
-    # append .internal (or user domain) to ensure domain suffix for Docker DNS resolver is used
+    # append .example (or user domain) to ensure domain suffix for Docker DNS resolver is used
     # since search domains are not appended to /etc/resolv.conf
-    @test_agent = "puppet_test#{Random.rand(1000)}.#{ENV['DOMAIN'] || 'internal'}"
+    @test_agent = "puppet_test#{Random.rand(1000)}.#{ENV['DOMAIN'] || 'example'}"
     @timestamps = []
     status = docker_compose('version')[:status]
     if status.exitstatus != 0


### PR DESCRIPTION
 - This compose file is intended to serve as an example to end users
   that can / should be modified to meet their needs.

   Therefore, switch to .example from .internal

 - Also note that the hope is that this reduces failures of PDB to
   resolve postgres.internal, which happen intermittently under LCOW

   Since .internal is not reserved like .example is, this may simplify
   DNS lookups against the Docker DNS resolver