### PR TITLE
(maint) Add Postgres healthcheck to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
   puppet:
@@ -33,6 +33,12 @@ services:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb
       - POSTGRES_DB=puppetdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=puppetdb --dbname=puppetdb"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 90s
     expose:
       - 5432
     volumes:

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -259,11 +259,13 @@ module SpecHelpers
   # Postgres Helpers
   ######################################################################
 
+  # @deprecated
   def count_postgres_database(database, service = 'postgres')
     cmd = "exec -T #{service} psql -t --username=puppetdb --command=\"SELECT count(datname) FROM pg_database where datname = '#{database}'\""
     docker_compose(cmd)[:stdout].strip
   end
 
+  # @deprecated
   def wait_on_postgres_db(database = 'puppetdb', seconds = 240, service = 'postgres')
     return retry_block_up_to_timeout(seconds) do
       count_postgres_database(database, service) == '1' ? '1' :

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -3,7 +3,7 @@ shared_context "running_cluster", :shared_context => :metadata do
 
   before(:each) do
     docker_compose_up()
-    wait_on_postgres_db('puppetdb')
+    wait_on_service_health('postgres', seconds = 240)
   end
 end
 


### PR DESCRIPTION
 - This provides useful feedback to `docker-compose ps`, so that
   it can be known when the database `puppetdb` is ready.

   This removes the need for separate helpers to execute queries to
   count the database.

   Update the specs to use the generic service healthy waiter in
   conjunction with the new postgres healthcheck.

 - Deprecate (but don't yet remove) the old helper methods.