### PR TITLE
(maint) Update retry_block_up_to_timeout semantics

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -211,7 +211,11 @@ module SpecHelpers
   def wait_on_service_health(service, seconds = 180)
     # services with healthcheck should deal with their own timeouts
     return retry_block_up_to_timeout(seconds, exit_early_on_error_type: ContainerNotFoundError) do
-      status = get_container_status(get_service_container(service))
+      service_container = get_service_container(service)
+      if get_container_state(service_container) == 'exited'
+        raise ContainerNotFoundError.new("Service #{service} (container: #{service_container}) has exited")
+      end
+      status = get_container_status(service_container)
       (status == 'healthy' || status == "'healthy'") ? 'healthy' :
         raise("#{service} is not healthy - currently #{status}")
     end

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -8,6 +8,8 @@ require 'openssl'
 module Pupperware
 module SpecHelpers
 
+  class ContainerNotFoundError < StandardError; end
+
   IS_WINDOWS = !!File::ALT_SEPARATOR
 
   def require_test_image()
@@ -48,20 +50,20 @@ module SpecHelpers
     { status: status, stdout: stdout_string }
   end
 
-  def retry_block_up_to_timeout(timeout, &block)
-    ex = nil
+  def retry_block_up_to_timeout(timeout, exit_early_on_error_type: [], raise_custom_error_type: nil, &block)
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     loop do
       begin
         return yield
-      rescue => e
-        ex = e
-        sleep(1)
-      ensure
+      rescue
+        raise $! if [exit_early_on_error_type].flatten.include?($!.class)
         if (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) > timeout
-          raise Timeout::Error.new(ex)
+          raise raise_custom_error_type.nil? ?
+            Timeout::Error.new :
+            raise_custom_error_type.new
         end
+        sleep(1)
       end
     end
   end
@@ -129,8 +131,8 @@ module SpecHelpers
     ids.lines.map(&:chomp)
   end
 
-  def get_service_container(service, timeout = 120)
-    return retry_block_up_to_timeout(timeout) do
+  def get_service_container(service, timeout = 5)
+    return retry_block_up_to_timeout(timeout, raise_custom_error_type: ContainerNotFoundError) do
       container = docker_compose("ps --quiet #{service}")[:stdout].chomp
       if container.empty?
         raise "docker-compose never started a service named '#{service}' in #{timeout} seconds"
@@ -208,7 +210,7 @@ module SpecHelpers
 
   def wait_on_service_health(service, seconds = 180)
     # services with healthcheck should deal with their own timeouts
-    return retry_block_up_to_timeout(seconds) do
+    return retry_block_up_to_timeout(seconds, exit_early_on_error_type: ContainerNotFoundError) do
       status = get_container_status(get_service_container(service))
       (status == 'healthy' || status == "'healthy'") ? 'healthy' :
         raise("#{service} is not healthy - currently #{status}")


### PR DESCRIPTION
 - This adds two new named arguments to retry_block_up_to_timeout

   * exit_early_on_error_type - this indicates classifications of
     errors to fail fast on
   * raise_custom_error_type - this indicates a custom error to raise
     when things timeout instead of Timeout::Error

 - These new parameters allow for get_service_container to raise a
   new error type on timeout: ContainerNotFoundError

 - wait_on_service_healthy can now fail fast by treating the
   ContainerNotFoundError as fatal, rather than retryable, like most
   errors

 - Also restructure the error handling inside retry_block_up_to_timeout
   so that there is no longer an ensure block. If errors are raised
   inside of `rescue` (as of Ruby 2.1) they will properly set the raised
   error `backtrace` and `cause` properties. This is not the behavior
   when raising inside the ensure block. Further, use the automatic
   $! variable instead of stowing off a named local variable.

 - When checking the service health of a container that was successfully
   started, but that terminated early, the container can still be
   inspected and is considered 'unhealthy', even if it has exited

   Check for "exited" state and fail fast like we're doing if the
   container doesn't exist.

   Exited containers do our tests no good.