### PR TITLE
(maint) Don't emit logs twice

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -263,8 +263,8 @@ module SpecHelpers
   def emit_log(container)
     container_name = get_container_name(container)
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
-    logs = run_command("docker logs --details --timestamps #{container}")[:stdout]
-    STDOUT.puts(logs)
+    # run_command streams stdout / stderr
+    run_command("docker logs --details --timestamps #{container}")[:stdout]
   end
 
   def teardown_container(container)


### PR DESCRIPTION
 - emit_log uses run_command to stream stdout / stderr *and* also
   emitted the captured output with STDOUT.puts afterwards

   remove the redundant STDOUT.puts