### PR TITLE
(maint) make sure docker logs are ordered properly

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -264,7 +264,7 @@ module SpecHelpers
     container_name = get_container_name(container)
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
     # run_command streams stdout / stderr
-    run_command("docker logs --details --timestamps #{container}")[:stdout]
+    run_command("docker logs --details --timestamps #{container} 2>&1")[:stdout]
   end
 
   def teardown_container(container)


### PR DESCRIPTION
 - merge stdout / stderr streams from `docker logs` because they will
   get split inside run_command and may end up out of order

 - with everything written to stdout, ordering should be consistent
   with what docker emits
da2ded2
