### PR TITLE
(maint) Set default wait_on_service_health timeout

### DIFF
--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -3,7 +3,7 @@ shared_context "running_cluster", :shared_context => :metadata do
 
   before(:each) do
     docker_compose_up()
-    wait_on_service_health('postgres', seconds = 240)
+    wait_on_service_health('postgres')
   end
 end
 
@@ -23,7 +23,7 @@ shared_examples 'a running pupperware cluster' do
   end
 
   it 'should start puppetdb' do
-    expect(wait_on_service_health('puppetdb', 240)).to eq('healthy')
+    expect(wait_on_service_health('puppetdb')).to eq('healthy')
   end
 
   it 'should include postgres extensions' do


### PR DESCRIPTION
 - For containers with a healthcheck set, we can determine timeout values
   to wait on the service automagically from the healthcheck spec

 - Default to 180 seconds as was done previously when no healthcheck
   present

 - Note that wait_on_service_health now will only find the container for
   a service before looping, which is a minor change to the previous
   flow. get_service_container is already set to wait up to 5 seconds
   to resolve -- if `docker-compose up` returned, the service should be
   immediately resolvable, even if the container is still starting

 - Remove extraneous explicit timeout values from specs

 - Add diagnostic message with the wait time


### Postgres

https://github.com/puppetlabs/pupperware/blob/master/docker-compose.yml#L36-L42

```yaml
healthcheck:
      # existence check for puppetdb database
      test: [ 'CMD-SHELL', "psql --username=puppetdb puppetdb -c ''" ]
      interval: 10s
      timeout: 5s
      retries: 6
      start_period: 90s
```

Output

```
service named 'postgres' is hosted in container: 'f06887ce6870fb7e6ff092700a459c27e5f0de6fdfba9bf40f7075f253f3c3c5'
f06887ce6870fb7e6ff092700a459c27e5f0de6fdfba9bf40f7075f253f3c3c5 - {{json .Config.Healthcheck}} : {"Test":["CMD-SHELL","psql --username=puppetdb puppetdb -c ''"],"Interval":10000000000,"Timeout":5000000000,"StartPeriod":90000000000,"Retries":6}
Waiting up to 150 seconds for service postgres to be healthy...
```

### Puppetserver

https://github.com/puppetlabs/puppetserver/blob/master/docker/puppetserver-standalone/Dockerfile#L99

```Dockerfile
HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD ["/healthcheck.sh"]
```

Output

```
service named 'puppet' is hosted in container: 'dee4af579b6cde8a4f5aea82227391d1316f92cf7c29a9997b62739e9e3c2847'
dee4af579b6cde8a4f5aea82227391d1316f92cf7c29a9997b62739e9e3c2847 - {{json .Config.Healthcheck}} : {"Test":["CMD","/healthcheck.sh"],"Interval":10000000000,"Timeout":10000000000,"Retries":90}
Waiting up to 900 seconds for service puppet to be healthy...
```

### PuppetDB

https://github.com/puppetlabs/puppetdb/blob/master/docker/puppetdb/Dockerfile#L99

```Dockerfile
HEALTHCHECK --start-period=5m --interval=10s --timeout=10s --retries=6 CMD ["/healthcheck.sh"]
```

Output

```
service named 'puppetdb' is hosted in container: '41d693cef5707a6bf7256241e91e01be7fdac8b96748c83a31a5c72388234ea2'
41d693cef5707a6bf7256241e91e01be7fdac8b96748c83a31a5c72388234ea2 - {{json .Config.Healthcheck}} : {"Test":["CMD","/healthcheck.sh"],"Interval":10000000000,"Timeout":10000000000,"StartPeriod":300000000000,"Retries":6}
Waiting up to 360 seconds for service puppetdb to be healthy...
```

