### PR TITLE
(maint) Remove get_service_container spec timeouts

### DIFF
--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -13,9 +13,9 @@ shared_examples 'a running pupperware cluster' do
   include_context 'running_cluster'
 
   it 'should start all of the cluster services' do
-    expect(get_service_container('puppet', 120)).to_not be_empty
-    expect(get_service_container('postgres', 60)).to_not be_empty
-    expect(get_service_container('puppetdb', 60)).to_not be_empty
+    expect(get_service_container('puppet')).to_not be_empty
+    expect(get_service_container('postgres')).to_not be_empty
+    expect(get_service_container('puppetdb')).to_not be_empty
   end
 
   it 'should start puppetserver' do


### PR DESCRIPTION
 - Retrieving a container from a service name should be immediate after
   calling docker-compose up

   There shouldn't be any need for a long timeout, or anything other
   than the 5 second default timeout