### PR TITLE
(maint) Force prune volumes / networks in Azure

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -138,10 +138,10 @@ function Clear-ComposeLeftOvers
     docker container prune --force
 
     Write-Host "`nPruning Volumes"
-    docker volume prune
+    docker volume prune --force
 
     Write-Host "`nPruning Networks"
-    docker network prune
+    docker network prune --force
 }
 
 function Remove-ContainerVolumeRoot


### PR DESCRIPTION
 - `docker volume prune` doesn't seem to be removing everything that
   is expected. `--force` is supposed to be necessary to remove
   prompting, so add that flag since these scripts are non-interactive