### PR TITLE
(maint) Emit container labels on docker-compose up

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -110,6 +110,10 @@ module SpecHelpers
     docker_compose('images')
     # TODO: use --all when docker-compose fixes https://github.com/docker/compose/issues/6579
     docker_compose('ps')
+    get_containers().each do |id|
+      labels = (get_container_labels(id).map { |k, v| "#{k}: #{v}"} || []).join("\n")
+      STDOUT.puts("Container #{id} labels:\n#{labels}\n\n")
+    end
   end
 
   def docker_compose_down()
@@ -233,6 +237,11 @@ module SpecHelpers
 
   def get_container_name(container)
     inspect_container(container, '{{.Name}}')
+  end
+
+  def get_container_labels(container)
+    json = inspect_container(container, '{{json .Config.Labels}}')
+    JSON.parse(json)
   end
 
   def get_container_state(container)

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -26,7 +26,7 @@ describe 'The docker-compose file works' do
     # LCOW requires directories to exist
     create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
     # ensure all containers are latest versions
-    docker_compose('pull --quiet')
+    docker_compose('pull --quiet', stream: STDOUT)
   end
 
   after(:all) do
@@ -48,7 +48,7 @@ describe 'The docker-compose file works' do
     it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
       expect(get_containers()).not_to be_empty
       # don't use shared helper as it removes volumes
-      docker_compose('down')
+      docker_compose('down', stream: STDOUT)
       expect(get_containers()).to be_empty
     end
 


### PR DESCRIPTION
 - It's useful to know what components are inside a given launched
   container.

   Even though we have an image id, it may be difficult to
   cross-reference back to the actual Puppet / PE component versions
   inside the container.


- This also fixes a problem in how `docker_compose` works that was introduced in https://github.com/puppetlabs/pupperware/pull/116 (specifically https://github.com/puppetlabs/pupperware/commit/980a755b7bb51d9454a5ba88115b1f7ef62604a2#diff-4cd2814855bdc73a2d390ef1cf973ae7R189) 