### PR TITLE
(maint) Fix get_container_labels on empty response

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -241,7 +241,8 @@ module SpecHelpers
 
   def get_container_labels(container)
     json = inspect_container(container, '{{json .Config.Labels}}')
-    JSON.parse(json)
+    json = 'null' if json.empty?
+    JSON.parse(json) || {}
   end
 
   def get_container_state(container)


### PR DESCRIPTION
 - Apparently if Docker misbehaves, it may not return labels given the
   {{json .Config.Labels}} query. Since this call currently happens
   inside of docker_compose_up, it usually causes a suite failure.

   Since get_container_labels is really only informational now,
   handle the docker cli returning an empty response.