### PR TITLE
(maint) Use named volumes in compose where possible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
       - PUPPETDB_SERVER_URLS=https://puppetdb.${DOMAIN:-internal}:8081
     volumes:
-      - ${VOLUME_ROOT:-.}/volumes/code:/etc/puppetlabs/code/
-      - ${VOLUME_ROOT:-.}/volumes/puppet:/etc/puppetlabs/puppet/
-      - ${VOLUME_ROOT:-.}/volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/
+      - puppetserver-code:/etc/puppetlabs/code/
+      - puppetserver-config:/etc/puppetlabs/puppet/
+      - puppetserver-data:/opt/puppetlabs/server/data/puppetserver/
     dns_search: ${DOMAIN:-internal}
     networks:
       default:
@@ -43,6 +43,7 @@ services:
     expose:
       - 5432
     volumes:
+      # only bind mounts currently work under LCOW for Postgres
       - ${VOLUME_ROOT:-.}/volumes/puppetdb-postgres/data:/var/lib/postgresql/data
       - ./postgres-custom:/docker-entrypoint-initdb.d
     dns_search: ${DOMAIN:-internal}
@@ -68,9 +69,15 @@ services:
       - postgres
       - puppet
     volumes:
-      - ${VOLUME_ROOT:-.}/volumes/puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+      - puppetdb-ssl:/etc/puppetlabs/puppet/ssl/
     dns_search: ${DOMAIN:-internal}
     networks:
       default:
         aliases:
          - puppetdb.${DOMAIN:-internal}
+
+volumes:
+  puppetserver-code:
+  puppetserver-config:
+  puppetserver-data:
+  puppetdb-ssl:

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -6,10 +6,6 @@ describe 'The docker-compose file works' do
   include Pupperware::SpecHelpers
 
   VOLUMES = [
-    'volumes/code',
-    'volumes/puppet',
-    'volumes/serverdata',
-    'volumes/puppetdb/ssl',
     'volumes/puppetdb-postgres/data'
   ]
 
@@ -23,7 +19,7 @@ describe 'The docker-compose file works' do
       fail "`docker-compose` must be installed and available in your PATH"
     end
     teardown_cluster()
-    # LCOW requires directories to exist
+    # LCOW requires bind mount directories to exist
     create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
     # ensure all containers are latest versions
     docker_compose('pull --quiet', stream: STDOUT)


### PR DESCRIPTION
 - docker-compose supports named volumes, which are different than the
   bind mounts that have been used thus far

   bind mounts expect that the host directory exists on disk and their
   behavior is a bit different, and is discussed in the docs at:

	 https://docs.docker.com/storage/bind-mounts/

 - While LCOW is happy to support both volumes and bind mounts, support
   from the platform is a bit different. Specifically it appears that
   bind mounts properly support hardlinks (necessary during Postgres
   startup), while volumes do not. An issue has been filed to track that
   issue at https://github.com/moby/moby/issues/39922 (originally filed at https://github.com/microsoft/opengcs/issues/337)

 - Switch all volumes to named, except for the one Postgres data volume
   which must remain a bind mount