### PR TITLE
(maint) Remove all `docker inspect` log output

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -201,7 +201,6 @@ module SpecHelpers
   def inspect_container(container, query)
     result = run_command("docker inspect \"#{container}\" --format \"#{query}\"", stream: StringIO.new)
     status = result[:stdout].chomp
-    STDOUT.puts "#{container} - #{query} : #{status}\n"
     return status
   end
 
@@ -275,6 +274,7 @@ module SpecHelpers
       if health.nil?
         raise("#{service} does not define a healthcheck")
       elsif (health.Status == 'healthy' || health.Status == "'healthy'")
+        STDOUT.puts("Service #{service} (container: #{service_container}) is healthy")
         return 'healthy'
       else
         log = health.Log.last()
@@ -312,8 +312,8 @@ module SpecHelpers
   end
 
   def teardown_container(container)
-    STDOUT.puts("Tearing down test container")
     network_id = get_container_network(container)
+    STDOUT.puts("Tearing down test container #{container} - disconnecting from network #{network_id}")
     run_command("docker network disconnect -f #{network_id} #{container}")
     run_command("docker container rm --force #{container}")
   end
@@ -480,7 +480,7 @@ module SpecHelpers
 
     # setting up a Windows TTY is difficult, so we don't
     # allocating a TTY will show container pull output on Linux, but that's not good for tests
-    STDOUT.puts("running agent #{agent_name} in network #{network} against #{server}")
+    STDOUT.puts("running agent #{agent_name} in network #{network} against #{server} / ca #{ca}")
     result = run_command("docker run --rm --network #{network} --name #{agent_name} --hostname #{agent_name} puppet/puppet-agent-ubuntu agent --verbose --onetime --no-daemonize --summarize --server #{server} --masterport #{masterport} --ca_server #{ca} --ca_port #{ca_port}")
     return result[:status].exitstatus
   end


### PR DESCRIPTION
 - In nearly all cases, the query / response from Docker did not need to
   be explicitly logged because the consumers of the values were already
   logging the important parts to STDOUT

 - This should reduce spec log chatter

 - Also improve failure messages to propagate exit reasons from the health info, when available. For instance (from https://dev.azure.com/puppetlabs/pupperware/_build/results?buildId=4182&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9):

```
1) The docker-compose file works the cluster starts should start puppetdb
     Failure/Error: expect(wait_on_service_health('puppetdb')).to eq('healthy')

     Pupperware::SpecHelpers::ContainerNotFoundError:
       Service puppetdb (container: d0f0d948d77932b0f711f3e1e681c484c8be58041b84628a753a46b74df6cb98) has exited
       Exit [1] - + set -e
       + grep -q "state":"running"+ curl --fail --resolve puppetdb:8080:127.0.0.1 http://puppetdb:8080/status/v1/services/puppetdb-status

         % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                        Dload  Upload   Total   Spent    Left  Speed
       
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to puppetdb port 8080: Connection refused
       + exit 1
     Shared Example Group: "a running pupperware cluster" called from ./spec/dockerfile_spec.rb:38
     # ./gem/lib/pupperware/spec_helper.rb:275:in `block in wait_on_service_health'
     # ./gem/lib/pupperware/spec_helper.rb:65:in `block in retry_block_up_to_timeout'
     # ./gem/lib/pupperware/spec_helper.rb:63:in `loop'
     # ./gem/lib/pupperware/spec_helper.rb:63:in `retry_block_up_to_timeout'
     # ./gem/lib/pupperware/spec_helper.rb:270:in `wait_on_service_health'
     # ./spec/examples/running_cluster.rb:26:in `block (2 levels) in <top (required)>'

```