### PR TITLE
(maint) run_command helper must wait for output

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -315,6 +315,7 @@ module SpecHelpers
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
     # run_command streams stdout / stderr
     run_command("docker logs --details --timestamps #{container} 2>&1")[:stdout]
+    STDOUT.puts("#{'*' * 80}\nEnd container logs for #{container_name} / #{container}\n#{'*' * 80}\n\n")
   end
 
   def teardown_container(container)


### PR DESCRIPTION
 - previously stdout / stderr threads could race and terminate prior to
   them finishing their work and writing to variable state

 - this would frequently result in truncated output inside Azure

 - follow a similar pattern as implemented in capture3
   ruby/ruby:lib/open3.rb@master#L271-L301

   - wait on stdout / stderr reader threads
   - wait on process thread

 - add a footer to the emit_logs output