### PR TITLE
(MAINT) Fix pull_images

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -166,9 +166,9 @@ module SpecHelpers
       puts "Pulling images"
     else
       puts "Pulling images (ignoring image for service #{ignore_service})"
-      services = services.gsub(ignore_service, '')
-      services = services.gsub("\n", ' ')
+      services.sub!(/^#{ignore_service}$/, '')
     end
+    services.gsub!("\n", ' ')
     docker_compose("pull --quiet #{services}", stream: STDOUT)
   end
 


### PR DESCRIPTION
Newlines need to be replaced all the time, which was previously only
happening when an argument was provided.

Also fix the substitution so it only replaces whole words and not
partial words, which would otherwise cause problems when we had both a
'puppet' and 'puppet-agent' service.