### PR TITLE
(maint) Enable Docker VOLUMEs for LCOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ which you will run your Puppet Infrastructure.
 
 ## Provisioning
 
-Once you have Docker Compose installed, you can start the stack on Linux or macOS with:
+Once you have Docker Compose installed, you can start the stack on Linux or OSX with:
 ```
     DNS_ALT_NAMES=host.example.com docker-compose up -d
 ```
@@ -47,44 +47,44 @@ account any custom domain.
     DOMAIN=foo docker-compose up -d
 ```
 
-When you first start the Puppet Infrastructure, the stack will create a
-`volumes/` directory with a number of sub-directories to store the
-persistent data that should survive the restart of your infrastructure. This
-directory is created right next to the Docker Compose file and contains the
-following sub-directories:
+When you first start the Puppet Infrastructure, the stack will create a number of Docker volumes to store the persistent data that should survive the restart of your infrastructure. The actual location on disk of these volumes may be examined with the `docker inspect` command. The following volumes include:
 
-* `code/`: the Puppet code directory.
-* `puppet/`: Puppet configuration files, including `puppet/ssl/` containing
-certificates for your infrastructure. This directory is populated with
-default configuration files if they are not present when the stack starts
-up. You can make configuration changes to your stack by editing files in
-this directory and restarting the stack.
-* `puppetdb/ssl/`: certificates in use by the PuppetDB instance in the
+* `puppetserver-code`: the Puppet code directory.
+* `puppetserver-config`: Puppet configuration files, including `puppet/ssl/` containing certificates for your infrastructure. This volume is populated with default configuration files if they are not present when the stack starts
+up.
+* `puppetdb-ssl`: certificates in use by the PuppetDB instance in the
   stack.
-* `puppetdb-postgres/`: the data files for the PostgreSQL instance used by
+* `puppetdb-postgres`: the data files for the PostgreSQL instance used by
 PuppetDB
-* `serverdata/`: persistent data for Puppet Server
-* Note: On OSX, you must add the `volumes` directory to "File Sharing" under
-  `Preferences>File Sharing` in order for these directories to be created
-  and volume-mounted automatically. There is no need to add each sub directory.
+* `puppetserver-data`: persistent data for Puppet Server
 
 ## Pupperware on Windows (using LCOW)
 
 Complete instructions for provisiong a server with LCOW support are in [README-windows.md](./README-windows.md)
 
-Due to [permissions issues with Postgres](https://forums.docker.com/t/trying-to-get-postgres-to-work-on-persistent-windows-mount-two-issues/12456/4) on Docker for Windows, to run under the LCOW environment, the Windows stack relies on the [`stellirin/postgres-windows`](https://hub.docker.com/r/stellirin/postgres-windows/) Windows variant of the upstream [`postgres`](https://hub.docker.com/_/postgres/) container instead.
-
-To create the stack:
+Creating the stack from PowerShell is nearly identical to other platforms, aside from how environment variables are declared:
 
 ``` powershell
 PS> $ENV:DNS_ALT_NAMES = 'host.example.com'
 
-PS> docker-compose -f .\docker-compose.yml -f .\docker-compose.windows.yml up
+PS> docker-compose up
 Creating network "pupperware_default" with the default driver
-Creating pupperware_puppet_1_4be38bcee346   ... done
-Creating pupperware_postgres_1_c82bfeb597f5 ... done
-Creating pupperware_puppetdb_1_bcd7e5f54a3f ... done
-Attaching to pupperware_postgres_1_cf9a935a098e, pupperware_puppet_1_79b6ff064b91, pupperware_puppetdb_1_70edf5d8cd1e
+Creating volume "pupperware_puppetserver-code" with default driver
+Creating volume "pupperware_puppetserver-config" with default driver
+Creating volume "pupperware_puppetserver-data" with default driver
+Creating volume "pupperware_puppetdb-ssl" with default driver
+Creating volume "pupperware_puppetdb-postgres" with default driver
+Creating pupperware_postgres_1 ...
+
+Creating pupperware_puppet_1   ...
+
+Creating pupperware_puppet_1   ... done
+
+Creating pupperware_postgres_1 ... done
+
+Creating pupperware_puppetdb_1 ...
+
+Creating pupperware_puppetdb_1 ... done
 
 ...
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,7 @@ services:
     expose:
       - 5432
     volumes:
-      # only bind mounts currently work under LCOW for Postgres
-      # https://github.com/moby/moby/issues/39922
-      - ${VOLUME_ROOT}puppetdb-postgres:/var/lib/postgresql/data
+      - puppetdb-postgres:/var/lib/postgresql/data
       - ./postgres-custom:/docker-entrypoint-initdb.d
     dns_search: ${DOMAIN:-internal}
     networks:
@@ -82,5 +80,4 @@ volumes:
   puppetserver-config:
   puppetserver-data:
   puppetdb-ssl:
-  # unused in LCOW since a bind mount is used instead - https://github.com/moby/moby/issues/39922
   puppetdb-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - 5432
     volumes:
       # only bind mounts currently work under LCOW for Postgres
-      - ${VOLUME_ROOT:-.}/volumes/puppetdb-postgres/data:/var/lib/postgresql/data
+      # https://github.com/moby/moby/issues/39922
+      - ${VOLUME_ROOT}puppetdb-postgres:/var/lib/postgresql/data
       - ./postgres-custom:/docker-entrypoint-initdb.d
     dns_search: ${DOMAIN:-internal}
     networks:
@@ -81,3 +82,5 @@ volumes:
   puppetserver-config:
   puppetserver-data:
   puppetdb-ssl:
+  # unused in LCOW since a bind mount is used instead - https://github.com/moby/moby/issues/39922
+  puppetdb-postgres:

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -74,6 +74,8 @@ function Build-Container(
     docker build $docker_args $PathOrUri
 }
 
+# NOTE: no longer necessary, but left in case need arises for temp bind mounts
+# https://github.com/moby/moby/issues/39922
 # set an Azure variable for temp volumes root
 # temp volumes root is deleted in Clear-ContainerBuilds
 function Initialize-TestEnv()
@@ -146,6 +148,8 @@ function Clear-ComposeLeftOvers
     docker network prune --force
 }
 
+# NOTE: no longer necessary, but left in case need arises for temp bind mounts
+# https://github.com/moby/moby/issues/39922
 function Remove-ContainerVolumeRoot
 {
     # delete directory if ENV variable is defined and directory actually exists

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -79,6 +79,8 @@ function Build-Container(
 function Initialize-TestEnv()
 {
     $tempVolumeRoot = Join-Path -Path $ENV:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
+    # tack on a trailing / or \
+    $tempVolumeRoot = Join-Path -Path $tempVolumeRoot -ChildPath ([System.IO.Path]::DirectorySeparatorChar)
     Write-Host "##vso[task.setvariable variable=VOLUME_ROOT]$tempVolumeRoot"
 }
 

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -150,6 +150,7 @@ module SpecHelpers
   end
 
   # Windows requires directories to exist prior, whereas Linux will create them
+  # @deprecated
   def create_host_volume_targets(root, volumes)
     return unless IS_WINDOWS
 

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -137,7 +137,8 @@ module SpecHelpers
     STDOUT.puts("Creating volumes directory structure in #{root}")
     volumes.each { |subdir| FileUtils.mkdir_p(File.join(root, subdir)) }
     # Hack: grant all users access to this temp dir for the sake of Docker daemon
-    run_command("icacls \"#{root}\" /grant Users:\"(OI)(CI)F\" /T")
+    # icacls can't have trailing slashes in the path, so remove with expand_path
+    run_command("icacls \"#{File.expand_path(root)}\" /grant Users:\"(OI)(CI)F\" /T")
   end
 
   def get_containers

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -5,10 +5,6 @@ require "#{File.join(File.dirname(__FILE__), 'examples', 'running_cluster.rb')}"
 describe 'The docker-compose file works' do
   include Pupperware::SpecHelpers
 
-  VOLUMES = [
-    'puppetdb-postgres'
-  ]
-
   before(:all) do
     # append .internal (or user domain) to ensure domain suffix for Docker DNS resolver is used
     # since search domains are not appended to /etc/resolv.conf
@@ -19,8 +15,6 @@ describe 'The docker-compose file works' do
       fail "`docker-compose` must be installed and available in your PATH"
     end
     teardown_cluster()
-    # LCOW requires bind mount directories to exist
-    create_host_volume_targets(ENV['VOLUME_ROOT'], VOLUMES)
     # ensure all containers are latest versions
     docker_compose('pull --quiet', stream: STDOUT)
   end

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -6,7 +6,7 @@ describe 'The docker-compose file works' do
   include Pupperware::SpecHelpers
 
   VOLUMES = [
-    'volumes/puppetdb-postgres/data'
+    'puppetdb-postgres'
   ]
 
   before(:all) do


### PR DESCRIPTION
### Part One

The first part of this PR was a crafty way to allow bind mounts to be used under LCOW, while allowing for named volumes to be used on Linux (for the same data - i.e. Postgres) without separate compose files: 

 - Previously this value would be a path like c:\windows\temp\1234.hzs, but
   change it to have a trailing slash like c:\windows\temp\1234.hzs\

 - This makes the VOLUME_ROOT value useful as a PATH prefix in a volume
   declaration inside compose (making it a bind mount instead of a VOLUME),
   but still allowing for a named volume when it is missing.

   For instance, assume the following in docker-compose.yml

```yml
   services:
     foo:
       volumes:
         - ${VOLUME_ROOT}foo:/tmp/bar

   volumes:
     foo:
```

   On Windows, with VOLUME_ROOT set as c:\windows\temp\1234.hzs\ the
   evaluation is:

```yml
   services:
     foo:
       volumes:
         - c:\windows\temp\1234.hzs\foo:/tmp/bar

   volumes:
     foo:
```

   A bind mount is used on Windows, instead of using the 'foo' volume
   which becomes extraneous (but harmless).

   On platforms that don't have VOLUME_ROOT defined, the evaluation is:

```yml
   services:
     foo:
       volumes:
         - foo:/tmp/bar

   volumes:
     foo:
```

  In this case, the named VOLUME 'foo' is used because a path is not
   specified (which would otherwise indicate a bind mount).

 - Carefully crafting this value allows for this flexibility across
   platforms, which is primarily useful for Postgres, which can only use
   bind mounts on Windows instead of VOLUMEs due to
   https://github.com/moby/moby/issues/39922

### Part Two

The second part switches Azure / LCOW over to named volumes!

 - Turns out LCOW *can* use Docker VOLUMEs with Postgres!

       As it turns out the problem was not one of bind mount vs VOLUME.
       Each LCOW VM `vmwp.exe` process (which in turn runs a single
       container) is assigned a randomized Windows user account in an
       effort to prevent VM breakout vulnerabilities.

       Unfortunately the volumes that a container owns (created in
       C:\ProgramData\Docker\volumes) are not granted full access to that
       user, which is necessary for symlink creation. So it turns out it
       *is* a permissions issue, but the problem is on the *Windows* side,
       not the Linux side!

 - For now, we can work around this problem by running the following on
       every LCOW host that we use for testing (will also update the
       Pupperware docs accordingly):

 > icacls C:\ProgramData\docker\volumes /grant *S-1-5-83-0:"(OI)(CI)F" /T

       All volumes created afterwards will inherit the `F` (FULL) permissions
       for the NT VIRTUAL MACHINE\Virtual Machines group (S-1-5-83-0).

 - This can't be done in each spec suite as the test runner agent runs a
       lower privilege account that can't change the permissions of files /
       directories within C:\ProgramData.

 - The reason this was never observed as a problem with bind mounts was
       due to ced39d78476272cee15e6810abf09a5526266b13 which grants the
       directory created for the bind mount with FULL access to all Users.
       This mitigates this problem (in the original case, auto-generated
       directories under the users temp directory, don't grant permissions
       to other users - so this allows the Docker process access to the path).

 - An issue has been filed in Moby to have the vmwp.exe process user
       associated with a given container granted full access to the volume
       paths it requires:
       https://github.com/moby/moby/issues/39922


### Part Three

- Update docs about LCOW + VOLUMEs