### PR TITLE
(maint) Improve pxp service wait method

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -511,12 +511,12 @@ module SpecHelpers
     end
   end
 
-  def wait_for_pxp_agent_to_connect(service: 'puppet-agent', timeout: 180)
+  def wait_for_pxp_agent_to_connect(agent_name: 'puppet-agent.test', timeout: 180)
+    generate_rbac_token()
     puts "Waiting for the puppet-agent's pxp-agent to connect to the pe-orchestration-service"
     return retry_block_up_to_timeout(timeout) do
-      command = "cat /var/log/puppetlabs/pxp-agent/pxp-agent.log"
-      output = docker_compose("exec -T #{service} #{command}")
-      raise("pxp-agent has not connected after #{timeout} seconds") if !output[:stdout].include?('Starting the monitor task')
+      output = curl_pe_orchestration_services("orchestrator/v1/inventory/#{agent_name}")
+      raise("pxp-agent has not connected after #{timeout} seconds") if !output.include?('"connected" : true')
     end
   end
 

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -515,8 +515,7 @@ module SpecHelpers
     generate_rbac_token()
     puts "Waiting for the puppet-agent's pxp-agent to connect to the pe-orchestration-service"
     return retry_block_up_to_timeout(timeout) do
-      output = curl_pe_orchestration_services("orchestrator/v1/inventory/#{agent_name}")
-      raise("pxp-agent has not connected after #{timeout} seconds") if !output.include?('"connected" : true')
+      raise("pxp-agent has not connected after #{timeout} seconds") if !JSON.parse(curl_pe_orchestration_services("orchestrator/v1/inventory/#{agent_name}"))['connected']
     end
   end
 


### PR DESCRIPTION
Previously we were catting the pxp-agent log to determine if it
has connected with the pcp-broker, all via a docker-compose call.
This PR changes that, now we depend on the pe-orchestration-services
to tell us if the pxp-agent is connected.
Since we're also no longer using docker-compose, we change out the
service name for the agent name in the parameters.