### PR TITLE
(MAINT) Fail fast if we're not on the VPN

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -56,6 +56,16 @@ function Lint-Dockerfile(
     if ($LASTEXITCODE -ne 0) { throw "ERROR: Linting $Path" }
 }
 
+function Test-NetworkAccess() {
+    if ($ENV:REQUIRE_ARTIFACTORY) {
+        try {
+            Invoke-RestMethod -Uri https://artifactory.delivery.puppetlabs.net/artifactory/api/system/ping -TimeoutSec 10
+        } catch {
+            throw 'ERROR: Artifactory cannot be reached or unhealthy. Are you on the VPN?'
+        }
+    }
+}
+
 function Build-Container(
     $Name,
     $Namespace = 'puppet',
@@ -68,6 +78,8 @@ function Build-Container(
     $Pull = $true,
     $AdditionalOptions = @())
 {
+    Test-NetworkAccess
+
     $build_date = (Get-Date).ToUniversalTime().ToString('o')
     $docker_args = @(
         '--build-arg', "version=$Version",


### PR DESCRIPTION
Since this is not meant for CI but local usage, put the check in
Build-Container so it fails immediately if we can't reach Artifactory.

Condition test on existence of REQUIRE_ARTIFACTORY environment variable,
so our FOSS repos can set this variable and skip this check.

----

```
PS /pe-console-services> Build-Container -Name 'foo'
Artifactory cannot be reached or unhealthy. Are you on the VPN?
At /pupperware/gem/ci/build.ps1:79 char:9
+         throw 'Artifactory cannot be reached or unhealthy. Are you on ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (Artifactory cannot \u2026Are you on the VPN?:String) [], RuntimeException
+ FullyQualifiedErrorId : Artifactory cannot be reached or unhealthy. Are you on the VPN?
```