### PR TITLE
Add ability to pull release when figuring out enterprise versioning

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -36,11 +36,11 @@ function Get-EnterpriseContainerVersion(
       Uri = "https://raw.githubusercontent.com/puppetlabs/enterprise-dist/$PeVer/packages.json"
       Headers = @{ "Authorization" = "token $Token" }
     }
-    $v = "" | Select-Object -Property version,release
     $packages = Invoke-RestMethod @params
-    $v.version = $packages."ubuntu-18.04-amd64"."$Package"."version"
-    $v.release = $packages."ubuntu-18.04-amd64"."$Package"."release"
-    $v
+    @{
+      Version = $packages."ubuntu-18.04-amd64"."$Package"."version"
+      Release = $packages."ubuntu-18.04-amd64"."$Package"."release"
+    }
 }
 
 # only need to specify -Name or -Path when calling

--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -89,12 +89,15 @@ function Build-Container(
         '--build-arg', "version=$Version",
         '--build-arg', "vcs_ref=$Vcs_ref",
         '--build-arg', "build_date=$build_date",
-        '--file', $Dockerfile,
-        '--tag', "$Namespace/${Name}:$Version"
+        '--file', $Dockerfile
     ) + $AdditionalOptions
 
     if ($Release -ne '') {
+        $docker_args += '--tag', "$Namespace/${Name}:$Version-$Release"
         $docker_args += '--build-arg', "release=$Release"
+    }
+    else {
+        $docker_args += '--tag', "$Namespace/${Name}:$Version"
     }
 
     if ($Pull) {


### PR DESCRIPTION
Will need to update the pe-puppetserver container to use the new syntax, that should happen around the same time this is merged in.