### PR TITLE
(maint) Enable DNS alt names in Puppetserver CA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # and must list all the names under which the puppetserver can be
       # reached. 'puppet.${DOMAIN:-internal}' must be one of them, otherwise puppetdb won't be
       # able to get a cert. Add other names as a comma-separated list
+      - CA_ALLOW_SUBJECT_ALT_NAMES=true
       - DNS_ALT_NAMES=puppet,puppet.${DOMAIN:-internal},${DNS_ALT_NAMES:-}
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
       - PUPPETDB_SERVER_URLS=https://puppetdb.${DOMAIN:-internal}:8081


### PR DESCRIPTION
 - Based on recent changes to PDB container, DNS_ALT_NAME is properly
   specified, requiring Puppetserver to enable alt name support in the
   CA:

   https://github.com/puppetlabs/puppetdb/pull/3082
   https://github.com/puppetlabs/puppetdb/pull/3082/commits/023bfcd0fd9e703e384e8167c768e61f22e46919#diff-cd7f09d157fc0b30e177f7a0c1977bbfR6


UPDATE: This also required a fix to the PDB container to properly open SSL port 8081 when `USE_PUPPETSERVER=true`. Unfortunately the spec suite for PDB didn't verify that and a line was missing from config. The jetty.ini config has been reworked in https://github.com/puppetlabs/puppetdb/pull/3086 and this PR can be re-run once a new container image with that code has shipped.