### PR TITLE
(maint) Fix helm chart

### DIFF
--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 0.2.0
+version: 0.2.1
 appVersion: 6.6.0
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/templates/hiera-configmap.yaml
+++ b/k8s/templates/hiera-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
   hiera.yaml: |-
-{{ .Values.hiera.config | indent 4 }}
+    {{ .Values.hiera.config | indent 4 }}
 {{- end }}

--- a/k8s/templates/private_key.pkcs7.pem.yaml
+++ b/k8s/templates/private_key.pkcs7.pem.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
   private_key.pkcs7.pem: |-
-{{ .Values.hiera.eyaml.private_key | indent 4 }}
+    {{ .Values.hiera.eyaml.private_key | indent 4 }}
 {{- end }}

--- a/k8s/templates/public_key.pkcs7.pem.yaml
+++ b/k8s/templates/public_key.pkcs7.pem.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "puppetserver.hiera.labels" . | nindent 4 }}
 data:
   public_key.pkcs7.pem: |-
-{{ .Values.hiera.eyaml.public_key | indent 4 }}
+    {{ .Values.hiera.eyaml.public_key | indent 4 }}
 {{- end }}

--- a/k8s/templates/puppetdb-deployment.yaml
+++ b/k8s/templates/puppetdb-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - containerPort: 8081
           volumeMounts:
             - name: puppetdb-storage
-              mountPath: /etc/puppetlabs/puppet/ssl/
+              mountPath: /opt/puppetlabs/server/data/puppetdb/certs/
       volumes:
         - name: puppetdb-storage
           persistentVolumeClaim:

--- a/k8s/templates/puppetserver-deployment.yaml
+++ b/k8s/templates/puppetserver-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: "{{.Values.puppetserver.fqdns.alternateServerNames}}"
             - name: PUPPETDB_SERVER_URLS
               value: https://puppetdb:8081
+            - name: CA_ALLOW_SUBJECT_ALT_NAMES
+              value: "true"
           ports:
             - containerPort: 8140
           volumeMounts:

--- a/k8s/templates/puppetserver-service.yaml
+++ b/k8s/templates/puppetserver-service.yaml
@@ -4,13 +4,13 @@ metadata:
   name: "puppet"
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
-{{- if .Values.puppetserver.service.labels }}
-{{ toYaml .Values.puppetserver.service.labels | indent 4 }}
-{{- end }}
-{{- if .Values.puppetserver.service.annotations }}
+  {{- if .Values.puppetserver.service.labels }}
+    {{ toYaml .Values.puppetserver.service.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.puppetserver.service.annotations }}
   annotations:
-{{ toYaml .Values.puppetserver.service.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml .Values.puppetserver.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: "puppetserver"


### PR DESCRIPTION
The puppetdb container was updated to include DNS alt names by default,
so we need to enable that in the puppetserver container. The default SSL
dir was also moved to simplify volumes in the puppetdb container, so
that has been updated as well.

Fixes #157 