### PR TITLE
(maint) Add stack waiting helper

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -269,7 +269,7 @@ module SpecHelpers
 
     # container won't be marked unhealthy during start period
     # then has a max number of retries over given interval before changing from starting to unhealthy
-    ((check.StartPeriod || 0) + (check.Interval * check.Retries)) / nanoseconds_to_seconds
+    ((check.StartPeriod || 0) + ((check.Interval + (check&.Timeout || 0)) * check.Retries)) / nanoseconds_to_seconds
   end
 
   def get_container_status(container)

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -3,7 +3,6 @@ shared_context "running_cluster", :shared_context => :metadata do
 
   before(:each) do
     docker_compose_up()
-    wait_on_service_health('postgres')
   end
 end
 
@@ -16,14 +15,6 @@ shared_examples 'a running pupperware cluster' do
     expect(get_service_container('puppet')).to_not be_empty
     expect(get_service_container('postgres')).to_not be_empty
     expect(get_service_container('puppetdb')).to_not be_empty
-  end
-
-  it 'should start puppetserver' do
-    expect(wait_on_service_health('puppet')).to eq('healthy')
-  end
-
-  it 'should start puppetdb' do
-    expect(wait_on_service_health('puppetdb')).to eq('healthy')
   end
 
   it 'should include postgres extensions' do


### PR DESCRIPTION
 - Previously the exit_early_on helper was tied very specifically to only
   exiting on specific error classes

   Refactor the method to instead accept an anonymous function that can
   be more flexible.

   This will be necessary to support early cancellation

 - Change the early_exit_on argument to be responsible for any exit
   implementation

   It is now responsible for either:

   * raising an error when appropriate, which exits the method
   * returning true to exit without error, which allows it to support
     non-raising error semantics for cancellation

 - Recalculate how much time to actually wait on a container for healthy
   based on how much time it's already been running.

   So if we've already waited 5 minutes for a container to be healthy,
   don't wait an additional 5 minutes. Pull the ripcord and abort
   early.

 - In addition to providing the last healthcheck log, provide the last
   3 lines from the containers logs for more context

 - Refactor wait_on_service_health helper into an additional helper
   that can be called with a container id rather than a service id

 - Update some of the log messages accordingly, and emit N/A in place
   of an unspecified service name when using the container based method

 - New method to wait on an entire compose stack, and abort early if
   *any* container fails while waiting.

   So test callers can just use this helper and dynamically determine
   what to wait for and how long.

 - This is made possible by the previous refactoring that allows a
   custom Proc to be used to determine how to exit. With that
   flexibility, we can now check a cancellation token on each
   wait cycle to see if the wait_on_container_health helper should
   stop waiting.

   When any thread raises an error, it sets the cancellation token
   that other threads are checking, effectively letting them know
   to exit at the next possible opportunity.

   All access to the cancellation token boolean is guarded with a mutex
   because variable writes are not atomic in Ruby.

   However, in practical terms, since this is a boolean, a mutex is not
   strictly an issue, and really only prevents an extra check / wait
   iteration for a thread that should be cancelled.

 - When waiting for all threads to complete, any that raise exceptions
   will continue to raise to callers, letting them know the method has
   failed, which typically results in a spec failure

   The abandoned threads will perform clean exits when they get the cancel
   signal and are later GC'd

 - Lastly, make wait_on_stack_healthy be automatically called during
   the docker_compose_up helper.

   This removes the need for any more explicit calls to wait_on_*_health
   helpers and any specs that individually assert those states