### PR TITLE
(maint) ContainerNotFoundError raise from inspect

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -289,6 +289,7 @@ module SpecHelpers
 
   def inspect_container(container, query)
     result = run_command("docker inspect \"#{container}\" --format \"#{query}\"", stream: StringIO.new)
+    raise ContainerNotFoundError.new(container) if result[:status].exitstatus != 0
     status = result[:stdout].chomp
     return status
   end


### PR DESCRIPTION
 - When checking on container health, use the inspect helper to be able
   to exit early

   wait_on_container_health already exits early when the error
   ContainerNotFoundError is raised anywhere in the call sequence

   This makes sure that if a container was initially up, but then
   totally crashed or otherwise disappeared while waiting on the
   healthcheck, that the waiter exits early