### PR TITLE
(maint) Handle exceptions in emit_logs / teardown

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -428,7 +428,7 @@ LOG
   end
 
   def emit_log(container)
-    container_name = get_container_name(container)
+    container_name = begin get_container_name(container) rescue 'N/A' end
     STDOUT.puts("#{'*' * 80}\nContainer logs for #{container_name} / #{container}\n#{'*' * 80}\n")
     # run_command streams stdout / stderr
     run_command("docker logs --details --timestamps #{container} 2>&1", stream: STDOUT)
@@ -436,7 +436,7 @@ LOG
   end
 
   def teardown_container(container)
-    network_id = get_container_network(container)
+    network_id = begin get_container_network(container) rescue 'missing' end
     STDOUT.puts("Tearing down test container #{container} - disconnecting from network #{network_id}")
     run_command("docker network disconnect -f #{network_id} #{container}")
     run_command("docker container rm --force #{container}")


### PR DESCRIPTION
 - Previous commit raises ContainerNotFoundError when a call to
   `docker inspect` fails, which can cause emit_logs and
   teardown_cluster to raise exceptions

   These are often called from an after(:suite) or after(:all) which
   can lead to unexpected failures in spec suites that don't properly
   cleanup or emit useful information