### PR TITLE
Revert "(maint) Fix Healthcheck waiter calculation"

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -327,7 +327,7 @@ module SpecHelpers
 
     # container won't be marked unhealthy during start period
     # then has a max number of retries over given interval before changing from starting to unhealthy
-    ((check.StartPeriod || 0) + ((check.Interval + (check&.Timeout || 0)) * check.Retries)) / nanoseconds_to_seconds
+    ((check.StartPeriod || 0) + (check.Interval * check.Retries)) / nanoseconds_to_seconds
   end
 
   def get_container_status(container)


### PR DESCRIPTION
I was so excited about fixing what I thought was a bug, I didn't realize it was correct before - ugh.

This reverts commit 6f7acf03e2114a731e1a7bf02e09b905be72e625.

This was right before! The healthcheck timeout doesn't factor until
the total amount of time its allowed to run before marking a
container as unhealthy.

Ooops... mathing is hard!