### PR TITLE
(maint) Emit container uptime after waiting

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -408,7 +408,8 @@ LOG
       if health.nil?
         raise("#{service} does not define a healthcheck")
       elsif (health.Status == 'healthy' || health.Status == "'healthy'")
-        STDOUT.puts("Service #{service} (container: #{container}) is healthy")
+        up = get_container_uptime_seconds(container)
+        STDOUT.puts("Service #{service} (container: #{container}) is healthy - running #{up.round(1)} seconds")
         return 'healthy'
       else
         raise("Service #{service} (container: #{container}) is not healthy - currently #{health.Status}\n#{log_msg}")


### PR DESCRIPTION
 - A little bit more useful diagnostic info


Example from successful run:

```
Waiting up to 165 seconds (running 15 already) for service postgres (container: 3ee9b011310981aa5ad45e69c1383362d5c4ca93a1d4b6cadc097ed0c252b06c) to be healthy...
Waiting up to 227 seconds (running 13 already) for service puppet (container: 356c81a4eec5a862a3509f0839cd37e1f8a7bf60ca75e1115bfa3e968bcf75f3) to be healthy...
Waiting up to 412 seconds (running 8 already) for service puppetdb (container: 9d52c9593996b3251af51275dfaa3410588d3084c9aec0eeace892099dd574fe) to be healthy...
Service postgres (container: 3ee9b011310981aa5ad45e69c1383362d5c4ca93a1d4b6cadc097ed0c252b06c) is healthy - running 86.4 seconds
Service puppet (container: 356c81a4eec5a862a3509f0839cd37e1f8a7bf60ca75e1115bfa3e968bcf75f3) is healthy - running 149.2 seconds
Service puppetdb (container: 9d52c9593996b3251af51275dfaa3410588d3084c9aec0eeace892099dd574fe) is healthy - running 177.7 seconds
```

Took Postgres 86 seconds, puppetserver 149 seconds and puppetdb 178 seconds to become healthy.