### PR TITLE
(MAINT) Make username/password parameters 

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -492,6 +492,7 @@ LOG
   ######################################################################
   # PE Console Services Helper
   ######################################################################
+
   def unrevoke_console_admin_user(postgres_container_name = "postgres")
     query = "exec -T #{postgres_container_name} psql --username=puppetdb --dbname=pe-rbac --command \"UPDATE subjects SET is_revoked = 'f' WHERE login='admin';\""
     output = docker_compose(query)[:stdout].chomp
@@ -502,13 +503,13 @@ LOG
     curl('localhost', 4433, end_point).body
   end
 
-  def generate_rbac_token()
+  def generate_rbac_token(rbac_username: 'admin', rbac_password: 'admin')
     uri = URI.parse("https://localhost:4433/rbac-api/v1/auth/token")
     request = Net::HTTP::Post.new(uri)
     request.content_type = "application/json"
     request.body = JSON.dump({
-                               "login" => "admin",
-                               "password" => "admin",
+                               "login" => rbac_username,
+                               "password" => rbac_password,
                                "lifetime" => "1h"
                              })
     req_options = {


### PR DESCRIPTION
So we can provide the username/password instead of rely on hardcoded
admin/admin being available.