### PR TITLE
(maint) Make sure Docker test bundle is fresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.24.0
+    - DOCKER_COMPOSE_VERSION=1.25.0-rc2
     - COMPOSE_PROJECT_NAME=pupperware
 
 before_install:


### PR DESCRIPTION
 - Need a bundle update to be able to pull the pupperware spec_helper
   (this primarily impacts local dev)