### PR TITLE
(MAINT) Common Makefile parts

### DIFF
--- a/gem/make/common.mk
+++ b/gem/make/common.mk
@@ -1,0 +1,13 @@
+VERSION ?= $(shell git describe | sed 's/-.*//')
+vcs_ref := $(shell git rev-parse HEAD)
+build_date := $(shell date -u +%FT%T)
+hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
+
+.PHONY: network-access prep cleanup lint build test publish push-image push-readme pull up down start stop
+
+network-access:
+ifneq ($(TRAVIS),true)
+	@curl https://artifactory.delivery.puppetlabs.net/artifactory/api/system/ping \
+		--connect-timeout 1 --silent --output /dev/null \
+	|| (echo 'ERROR: Artifactory cannot be reached or unhealthy. Are you on the VPN?' >&2; exit 1)
+endif

--- a/gem/make/foss.mk
+++ b/gem/make/foss.mk
@@ -1,0 +1,5 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/common.mk
+
+NAMESPACE ?= puppet
+LATEST_VERSION ?= latest

--- a/gem/make/pe.mk
+++ b/gem/make/pe.mk
@@ -1,0 +1,23 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/common.mk
+
+NAMESPACE ?= artifactory.delivery.puppetlabs.net/pe-and-platform
+VERSION ?= `jq '."ubuntu-18.04-amd64"."pe-puppetserver"."version"' $(PWD)/tmp/enterprise-dist/packages.json 2> /dev/null | tr -d '"'`
+RELEASE ?= `jq '."ubuntu-18.04-amd64"."pe-puppetserver"."release"' $(PWD)/tmp/enterprise-dist/packages.json 2> /dev/null | tr -d '"'`
+LATEST_VERSION ?= kearney-latest
+
+prep: cleanup
+	@git fetch --unshallow 2> /dev/null ||:
+	@git fetch origin 'refs/tags/*:refs/tags/*'
+	@mkdir -p $(PWD)/tmp
+ifeq ($(TRAVIS),true)
+	@git clone --quiet --single-branch --branch 2019.1.x --depth=1 https://github.com/puppetlabs/enterprise-dist $(PWD)/tmp/enterprise-dist
+else ifneq ($(DISTELLI_BUILDNUM),)
+	@git clone --quiet --single-branch --branch 2019.1.x --depth=1 https://$$GITHUB_TOKEN@github.com/puppetlabs/enterprise-dist $(PWD)/tmp/enterprise-dist
+else
+	@git clone --quiet --single-branch --branch 2019.1.x --depth=1 git@github.com:puppetlabs/enterprise-dist $(PWD)/tmp/enterprise-dist
+endif
+
+cleanup:
+	@rm -rf $(PWD)/tmp/enterprise-dist/
+	@rmdir $(PWD)/tmp 2> /dev/null ||: # remove the tmp dir if it's empty


### PR DESCRIPTION
Extract common variables and targets from our Makefiles into shared .mk
files that can be included by the refactored Makefiles.

----

See also: 
- https://github.com/puppetlabs/pe-orchestration-services/pull/162
- https://github.com/puppetlabs/pe-puppetserver/pull/402

----

The design here is:
- Common variables/targets/functions/etc go in `common.mk`
- FOSS-specific things go in `foss.mk` (which includes `common.mk`)
- PE-specific things go in `pe.mk` (which includes `common.mk`)

Then consuming Makefiles can either:
- `include foss.mk` if they're a FOSS repo
- `include pe.mk` if they're a PE repo