### PR TITLE
(maint) Add docker pull to the orchestrator job run command

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -10,6 +10,7 @@ require 'time'
 
 module Pupperware
 module SpecHelpers
+PE_CLIENT_TOOLS_IMAGE='artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:kearney-latest'
 
   class ContainerNotFoundError < StandardError; end
 
@@ -543,6 +544,7 @@ LOG
   end
 
   def orchestrate_puppet_run(target_agent: 'puppet-agent.test', network: 'pupperware-commercial', rbac_username: 'admin', rbac_password: 'pupperware', puppetserver: 'puppet.test', pe_console_services: 'pe-console-services.test', pe_orchestration_services: 'pe-orchestration-services.test')
+    run_command("docker pull #{PE_CLIENT_TOOLS_IMAGE}")
     run_command("docker run \
            --rm \
            --network #{network} \
@@ -550,7 +552,7 @@ LOG
            --env RBAC_PASSWORD=#{rbac_password} \
            --env PUPPETSERVER_HOSTNAME=#{puppetserver} \
            --env PE_CONSOLE_SERVICES_HOSTNAME=#{pe_console_services} \
-           artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:kearney-latest \
+           #{PE_CLIENT_TOOLS_IMAGE} \
            puppet-job run \
               --nodes #{target_agent} \
               --service-url https://#{pe_orchestration_services}:8143/")


### PR DESCRIPTION
Before using the pe-client-tools container we should make sure
we're using the most up to date version.