### PR TITLE
(maint) Simplify specs / re-enable testing after restart on Windows

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -348,6 +348,10 @@ module SpecHelpers
     inspect_container(container, '{{.State.Status}}')
   end
 
+  def get_container_restart_count(container)
+    inspect_container(container,'{{.RestartCount}}')
+  end
+
   def get_container_uptime_seconds(container)
     started_at = Time.parse(inspect_container(container, '{{ .State.StartedAt }}'))
     Time.now.utc - started_at
@@ -460,11 +464,11 @@ LOG
 
   def kill_service_and_wait_for_return(service: nil, process: nil, timeout: 20)
     container = get_service_container(service)
-    restart_count = inspect_container(container,'{{.RestartCount}}')
+    restart_count = get_container_restart_count(container)
     docker_compose("exec -T #{service} pkill #{process}")
 
     return retry_block_up_to_timeout(timeout) do
-      restart_count == inspect_container(container,'{{.RestartCount}}') ? true :
+      restart_count == get_container_restart_count(container) ? true :
       raise("Container #{service} never restarted")
     end
   end

--- a/spec/dockerfile_spec.rb
+++ b/spec/dockerfile_spec.rb
@@ -1,45 +1,36 @@
 #! /usr/bin/env ruby
 
 require "#{File.join(File.dirname(__FILE__), 'examples', 'running_cluster.rb')}"
+include Pupperware::SpecHelpers
+
+RSpec.configure do |c|
+  c.before(:suite) do
+    pull_images()
+    teardown_cluster()
+    docker_compose_up()
+  end
+
+  c.after(:suite) do
+    emit_logs
+    teardown_cluster()
+  end
+end
 
 describe 'The docker-compose file works' do
-  include Pupperware::SpecHelpers
-
   before(:all) do
+    @timestamps = []
     # append .internal (or user domain) to ensure domain suffix for Docker DNS resolver is used
     # since search domains are not appended to /etc/resolv.conf
-    @test_agent = "puppet_test#{Random.rand(1000)}.#{ENV['DOMAIN'] || 'internal'}"
-    @timestamps = []
-    status = docker_compose('version')[:status]
-    if status.exitstatus != 0
-      fail "`docker-compose` must be installed and available in your PATH"
-    end
-    teardown_cluster()
-    # ensure all containers are latest versions
-    docker_compose('pull --quiet', stream: STDOUT)
+    @test_agent ||= "puppet_test#{Random.rand(1000)}.#{ENV['DOMAIN'] || 'internal'}"
   end
 
-  after(:all) do
-    emit_logs()
-    teardown_cluster()
-  end
-
-  describe 'the cluster starts' do
+  describe 'when starting' do
     include_examples 'a running pupperware cluster'
   end
 
-  describe 'the cluster restarts' do
+  describe 'after the cluster restarts' do
     before(:all) do
-      @mapped_ports = {}
-    end
-
-    # don't run this on Windows because compose down takes forever
-    # https://github.com/docker/for-win/issues/629
-    it 'should stop the cluster', :if => File::ALT_SEPARATOR.nil? do
-      expect(get_containers()).not_to be_empty
-      # don't use shared helper as it removes volumes
-      docker_compose('down', stream: STDOUT)
-      expect(get_containers()).to be_empty
+      restart_stack()
     end
 
     include_examples 'a running pupperware cluster'

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -1,12 +1,6 @@
 shared_examples 'a running pupperware cluster' do
   require 'rspec/core'
 
-  it 'should start all of the cluster services' do
-    expect(get_service_container('puppet')).to_not be_empty
-    expect(get_service_container('postgres')).to_not be_empty
-    expect(get_service_container('puppetdb')).to_not be_empty
-  end
-
   it 'should include postgres extensions' do
     installed_extensions = get_postgres_extensions
     expect(installed_extensions).to match(/^\s+pg_trgm\s+/)

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -1,15 +1,5 @@
-shared_context "running_cluster", :shared_context => :metadata do
-  include Pupperware::SpecHelpers
-
-  before(:each) do
-    docker_compose_up()
-  end
-end
-
 shared_examples 'a running pupperware cluster' do
   require 'rspec/core'
-
-  include_context 'running_cluster'
 
   it 'should start all of the cluster services' do
     expect(get_service_container('puppet')).to_not be_empty


### PR DESCRIPTION
(maint) Refactor kill_service_and_wait_for_return

- Minor cleanup to use the retry_block_up_to_timeout helper
- This changes behavior slightly to poll every 1 second instead of 5,
  but follows the model already used elsewhere

(maint) Extract get_container_restart_count helper

- Refactor this helper for use elsewhere

(maint) Simplify / refactor specs

 - Do not call `docker-compose up` a bajillion times - it's only
   necessary to do it once at the start of the suite. This reduces
   log noise by quite a bit.

 - Add a new restart_stack helper method, which is responsible for doing
   a few things:

   - taking a count of each containers RestartCount
   - clear any cached host / port mappings
   - calling docker-compose restart
   - waiting for each container to change its RestartCount
   - calling wait_on_stack_healthy to make sure all containers are
     healthy prior to proceeding further

 - This also includes a new wait_on_container_restart helper which
   accepts the container name, the prior restart count, and a default
   number of seconds to wait before failing (20)

 - Refactor kill_service_and_wait_for_return to use
   wait_on_container_restart

 - Re-enable tests that weren't previously running on Windows given we
   have easy to use helpers that workaround our problems

 - Note that we previously called docker-compose down, when we really
   just wanted to call docker-compose restart to stop / start containers