### PR TITLE
Fix Permissions for Some Hiera, Puppet Server and eYaml Configs

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,11 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.0.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.0.1) (2019-11-11)
+- Fix Permissions for Hiera, Puppet Server and eYaml Configs.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.0.0...v1.0.1)
+
 ## [v1.0.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.0.0) (2019-11-08)
 - Differentiate "nodeSelector" for Pods with Common Storage.
 - Fix for PostgreSQL on AWS.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.0.0
+version: 1.0.1
 appVersion: 6.7.1
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/templates/puppetserver-deployment.yaml
+++ b/k8s/templates/puppetserver-deployment.yaml
@@ -30,7 +30,23 @@ spec:
           command: [ "sh", "-c" ]
           args:
             - mkdir -p /etc/puppetlabs/code/environments;
+              mkdir -p /etc/puppetlabs/puppet/keys;
+              mkdir -p /etc/puppetlabs/puppet/manifests;
               chown -R puppet:puppet /etc/puppetlabs;
+              {{- if .Values.hiera.config }}
+              cp /etc/puppetlabs/puppet/configmap/hiera.yaml /etc/puppetlabs/puppet/hiera.yaml;
+              chown puppet:puppet /etc/puppetlabs/puppet/hiera.yaml;
+              {{- end }}
+              cp /etc/puppetlabs/puppet/configmap/site.pp /etc/puppetlabs/puppet/manifests/site.pp;
+              chown puppet:puppet /etc/puppetlabs/puppet/manifests/site.pp;
+              {{- if .Values.hiera.eyaml.private_key }}
+              cp /etc/puppetlabs/puppet/configmap/private_key.pkcs7.pem /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
+              chown puppet:puppet /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem;
+              {{- end }}
+              {{- if .Values.hiera.eyaml.public_key }}
+              cp /etc/puppetlabs/puppet/configmap/public_key.pkcs7.pem /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
+              chown puppet:puppet /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem;
+              {{- end }}
               chmod -R 0777 /tmp;
           securityContext:
             runAsUser: 0
@@ -39,6 +55,26 @@ spec:
           volumeMounts:
             - name: puppet-code-storage
               mountPath: /etc/puppetlabs/code/
+            - name: puppet-puppet-storage
+              mountPath: /etc/puppetlabs/puppet/
+            {{- if .Values.hiera.config }}
+            - name: hiera-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/hiera.yaml
+              subPath: hiera.yaml
+            {{- end }}
+            - name: manifests-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/site.pp
+              subPath: site.pp
+            {{- if .Values.hiera.eyaml.public_key }}
+            - name: eyamlpub-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/public_key.pkcs7.pem
+              subPath: public_key.pkcs7.pem
+            {{- end }}
+            {{- if .Values.hiera.eyaml.private_key }}
+            - name: eyamlpriv-volume
+              mountPath: /etc/puppetlabs/puppet/configmap/private_key.pkcs7.pem
+              subPath: private_key.pkcs7.pem
+            {{- end }}            
             - name: puppet-hiera-storage
               mountPath: /tmp/
       containers:
@@ -69,24 +105,6 @@ spec:
               mountPath: /opt/puppetlabs/server/data/puppetserver/
             - name: puppet-hiera-storage
               mountPath: /hiera
-            {{- if .Values.hiera.config }}
-            - name: hiera-volume
-              mountPath: /etc/puppetlabs/puppet/hiera.yaml
-              subPath: hiera.yaml
-            {{- end }}
-            - name: manifests-volume
-              mountPath: /etc/puppetlabs/puppet/manifests/site.pp
-              subPath: site.pp
-            {{- if .Values.hiera.eyaml.public_key }}
-            - name: eyamlpub-volume
-              mountPath: /etc/puppetlabs/puppet/keys/public_key.pkcs7.pem
-              subPath: public_key.pkcs7.pem
-            {{- end }}
-            {{- if .Values.hiera.eyaml.private_key }}
-            - name: eyamlpriv-volume
-              mountPath: /etc/puppetlabs/puppet/keys/private_key.pkcs7.pem
-              subPath: private_key.pkcs7.pem
-            {{- end }}
         {{- if .Values.hiera.hieradataurl }}
         - name: git-sync-hiera
           image: "{{.Values.git_sync.image}}:{{.Values.git_sync.tag}}"


### PR DESCRIPTION
- Fix Permissions for Hiera, Puppet Server and eYaml Configs.

Fixes the following errors:
1. Running /docker-entrypoint.d/30-set-permissions.sh
chown: changing ownership of '/etc/puppetlabs/puppet/manifests/site.pp': Read-only file system
chown: changing ownership of '/etc/puppetlabs/puppet/keys/private_key.pkcs7.pem': Read-only file system
chown: changing ownership of '/etc/puppetlabs/puppet/keys/public_key.pkcs7.pem': Read-only file system
2. Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Neither PU key nor PRIV key: (file: /etc/puppetlabs/code/environments/dev/manifests/site.pp, line: 1, column: 1) on node [...]


Signed-off-by: Miroslav Hadzhiev <miroslav.hadzhiev@gmail.com>