### PR TITLE
(WIP)(maint) Run CI with pre-generated certs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ pool:
 
 variables:
   COMPOSE_PROJECT_NAME: pupperware
+  PRELOAD_CERTS: 1
 
 workspace:
   clean: resources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       - POSTGRES_PASSWORD=puppetdb
       - POSTGRES_USER=puppetdb
       - POSTGRES_DB=puppetdb
+      # to be able to preload certs, PGDATA must be empty when booting, so set
+      # its directory as a subdirectory of the default /var/lib/postgresql/data VOLUME
+      - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
       # existence check for puppetdb database
       test: [ 'CMD-SHELL', "psql --username=puppetdb puppetdb -c ''" ]


### PR DESCRIPTION
Depends on:

- [x] Merging #179 to load pre-generated certs
- [ ] Refactoring puppetserver container to have some locations as pe-puppetserver

- This will slightly speed up the puppetdb wait time

- Note that this requires moving PGDATA from /var/lib/postgresql/data
 to /var/lib/postgresql/data/pgdata. This is necessary because PGDATA
 must be empty when the container first starts to run initdb. With
 certs copied into a sub-directory of PGDATA, startup fails with a
 message like:

 initdb: directory "/var/lib/postgresql/data" exists but is not empty