### PR TITLE
Force r10k to Re-Parse `Puppetfile` at Each Run

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.2.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.2) (2019-11-26)
+- Fixes https://github.com/puppetlabs/pupperware/issues/187 and https://github.com/puppetlabs/pupperware/issues/188.
+- `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are now owned by Puppet Server.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
+
 ## [v1.2.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.1) (2019-11-24)
 - Fixes for "r10k" extra container args.
 - Values file small fixes.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.2.1
+version: 1.2.2
 appVersion: 6.7.1
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/templates/r10k-cronjob.yaml
+++ b/k8s/templates/r10k-cronjob.yaml
@@ -37,6 +37,7 @@ spec:
                 - environment
                 - --config
                 - /etc/puppetlabs/puppet/r10k.yaml
+                - --puppetfile
               {{- range $key, $value := .Values.r10k.extraArgs }}
                 - {{ $value }}
               {{- end }}


### PR DESCRIPTION
- Fixes: https://github.com/puppetlabs/pupperware/issues/187, https://github.com/puppetlabs/pupperware/issues/188.
- `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are owned by Puppet Server.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
