### PR TITLE
[K8s] Add support for separate r10k network protocols to gather the code of Puppet and Hiera repos

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,19 +5,30 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v1.2.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.2) (2019-11-26)
-- Fixes https://github.com/puppetlabs/pupperware/issues/187 and https://github.com/puppetlabs/pupperware/issues/188.
+## [v1.3.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.3.0) (2019-11-27)
+
+- [Firewall Related] Add support for separate r10k network protocols to gather the code of Puppet and Hiera repos.
+- Increase default r10k sync runtime interval to every 5 minutes.
+- Syntax improvements.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.2...v1.3.0)
+
+## [v1.2.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.2) (2019-11-24)
+
+- Fixes <https://github.com/puppetlabs/pupperware/issues/187> and <https://github.com/puppetlabs/pupperware/issues/188.>
 - `r10k` now runs with the `puppet` username and group id - meaning all the files in `/etc/puppetlabs` are now owned by Puppet Server.
 
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.1...v1.2.2)
 
-## [v1.2.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.1) (2019-11-24)
+## [v1.2.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.1) (2019-11-22)
+
 - Fixes for "r10k" extra container args.
 - Values file small fixes.
 
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.0...v1.2.1)
 
 ## [v1.2.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.2.0) (2019-11-21)
+
 - Add optional extra container environment variables.
 - Add optional "r10k" extra container arguments.
 - Bump PupptDB to v6.7.3.
@@ -27,16 +38,19 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.1.0...v1.2.0)
 
 ## [v1.1.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.1.0) (2019-11-19)
+
 - Switch Pulling the Hiera Data Repo from Using "git_sync" to "r10k".
 
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.0.1...v1.1.0)
 
 ## [v1.0.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.0.1) (2019-11-11)
+
 - Fix Permissions for Hiera, Puppet Server and eYaml Configs.
 
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.0.0...v1.0.1)
 
 ## [v1.0.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.0.0) (2019-11-08)
+
 - Differentiate "nodeSelector" for Pods with Common Storage.
 - Fix for PostgreSQL on AWS.
 - Small Syntax and Indentation Fixes.
@@ -46,12 +60,14 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.3.5...v1.0.0)
 
 ## [v0.3.5](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.3.5) (2019-10-31)
+
 - Add Optional `selector` for PVs/PVCs.
 - Switch to Apache v2.0 License.
 
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.3.4...v0.3.5)
 
 ## [v0.3.4](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.3.4) (2019-10-28)
+
 - Add Ingress.
 - Improve Tmpl Helpers.
 - Improve `NOTES`.
@@ -59,6 +75,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.3.3...v0.3.4)
 
 ## [v0.3.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.3.3) (2019-10-27)
+
 - Add Optional Static Data Volumes.
 - Add Configurable PVC's Size.
 - Add Optional PVC's Annotations.
@@ -66,6 +83,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.3.2...v0.3.3)
 
 ## [v0.3.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.3.2) (2019-10-26)
+
 - Add optional extra Pod Annotations.
 - Add optional Pod Priority Scheduling.
 - Add LICENSE.
@@ -76,6 +94,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.3.1...v0.3.2)
 
 ## [v0.3.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.3.1) (2019-10-24)
+
 - Add optional "nodeSelector", "affinity" and "tolerations" for Pod Deployments.
 - Improve Values Comments.
 - Bump Component Versions.
@@ -83,15 +102,17 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.2.4...v0.3.1)
 
 ## [v0.2.4](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.2.4) (2019-10-12)
+
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.2.3...v0.2.4)
 
 ## [v0.2.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.2.3) (2019-10-11)
+
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.2.2...v0.2.3)
 
 ## [v0.2.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.2.2) (2019-10-09)
+
 [Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v0.2.0...v0.2.2)
 
 ## [v0.2.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v0.2.0) (2019-09-20)
-
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,12 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.3.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.3.1) (2019-11-27)
+
+- Small Values file fix.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.3.0...v1.3.1)
+
 ## [v1.3.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.3.0) (2019-11-27)
 
 - [Firewall Related] Add support for separate r10k network protocols to gather the code of Puppet and Hiera repos.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.3.0
+version: 1.3.1
 appVersion: 6.7.2
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.2.2
-appVersion: 6.7.1
+version: 1.3.0
+appVersion: 6.7.2
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/
 icon: https://secure.gravatar.com/avatar/fdd009b7c1ec96e088b389f773e87aec.jpg?s=80&r=g&d=mm

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -3,15 +3,18 @@
 ## Prerequisites
 
 ### Code Repos
+
 * You must specify your Puppet Control Repo using `puppetserver.puppeturl` variable in the `values.yaml` file or include `--set puppetserver.puppeturl=<your_public_repo>` in the command line of `helm install`. You should specify your separate Hieradata Repo as well using the `hiera.hieradataurl` variable.
 
 * You can also use private repos. Just remember to specify your credentials using `r10k.viaHttps.credentials` or `r10k.viaSsh.credentials`. You can set similar credentials for your Hieradata Repo.
 
 ### Kubernetes Storage Class
+
 Depending on your deployment scenario a certain `StorageClass` object might be required.
 In a big K8s megacluster running in the cloud multiple labeled (and/or tainted) nodes in each Availability Zone (AZ) might be present. In such scenario Puppet Server components that use common storage (`puppetserver` and `r10k`) require their volumes to be created in the same AZ. That can be achieved through a custom `StorageClass`.
 
 Exemplary definition:
+
 ```yaml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -29,6 +32,7 @@ allowedTopologies:
 ```
 
 ### Load-Balancing Puppet Server
+
 In case a Load Balancer (LB) must sit in front of Puppet Server - please keep in mind that having a Network LB (operating at OSI Layer 4) is preferable.
 
 ## Chart Components
@@ -97,7 +101,7 @@ Parameter | Description | Default
 `puppetserver.image` | puppetserver image | `puppet/puppetserver`
 `puppetserver.tag` | puppetserver img tag | `6.7.1`
 `puppetserver.resources` | puppetserver resource limits | ``
-`puppetserver.extraEnv` | puppetserver additional container env vars | ``
+`puppetserver.extraEnv` | puppetserver additional container env vars |``
 `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`
 `puppetserver.fqdns.alternateServerNames` | puppetserver alternate fqdns |``
 `puppetserver.service.type` | puppetserver svc type | `ClusterIP`
@@ -116,14 +120,14 @@ Parameter | Description | Default
 `r10k.tag` | r10k img tag | `3.3.3`
 `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
 `r10k.cronJob.schedule` | r10k cron job schedule policy | `*/2 * * * *`
-`r10k.resources` | r10k resource limits | ``
-`r10k.extraArgs` | r10k additional container env args | ``
-`r10k.extraEnv` | r10k additional container env vars | ``
-`r10k.viaHttps.enabled` | r10k repo cloning via https | `true`
+`r10k.resources` | r10k resource limits |``
+`r10k.extraArgs` | r10k additional container env args |``
+`r10k.extraEnv` | r10k additional container env vars |``
+`r10k.viaHttps.repo`| r10k https repo selector |``
 `r10k.viaHttps.credentials.username`| r10k https username |``
 `r10k.viaHttps.credentials.password`| r10k https password |``
 `r10k.viaHttps.credentials.existingSecret`| r10k https secret that holds https username and password |``
-`r10k.viaSsh.enabled` | r10k repo cloning via https | `false`
+`r10k.viaSsh.repo`| r10k ssh repo selector |``
 `r10k.viaSsh.credentials.ssh.value`| r10k ssh key file |``
 `r10k.viaSsh.credentials.known_hosts.value`| r10k ssh known hosts file |``
 `r10k.viaSsh.credentials.existingSecret`| r10k ssh secret that holds ssh key and known hosts files |``
@@ -131,14 +135,14 @@ Parameter | Description | Default
 `postgres.image` | postgres img | `postgres`
 `postgres.tag` | postgres img tag | `9.6.15`
 `postgres.pullPolicy` | postgres img pull policy | `IfNotPresent`
-`postgres.resources` | postgres resource limits | ``
-`postgres.extraEnv` | postgres additional container env vars | ``
+`postgres.resources` | postgres resource limits |``
+`postgres.extraEnv` | postgres additional container env vars |``
 `puppetdb.name` | puppetdb component label | `puppetdb`
 `puppetdb.image` | puppetdb img | `puppet/puppetdb`
 `puppetdb.tag` | puppetdb img tag | `6.7.3`
 `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`
-`puppetdb.resources` | puppetdb resource limits | ``
-`puppetdb.extraEnv` | puppetdb additional container env vars | ``
+`puppetdb.resources` | puppetdb resource limits |``
+`puppetdb.extraEnv` | puppetdb additional container env vars |``
 `puppetdb.credentials.username`| puppetdb username |`puppetdb`
 `puppetdb.credentials.value.password`| puppetdb password |`20-char randomly generated`
 `puppetdb.credentials.password.existingSecret`| k8s secret that holds puppetdb password |``
@@ -148,8 +152,8 @@ Parameter | Description | Default
 `puppetboard.image` | puppetboard img | `puppet/puppetboard`
 `puppetboard.tag` | puppetboard img tag | `0.3.0`
 `puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`
-`puppetboard.resources` | puppetboard resource limits | ``
-`puppetboard.extraEnv` | puppetboard additional container env vars | ``
+`puppetboard.resources` | puppetboard resource limits |``
+`puppetboard.extraEnv` | puppetboard additional container env vars |``
 `hiera.name` | hiera component label | `hiera`
 `hiera.hieradataurl`| hieradata repo url |``
 `hiera.config`| hieradata yaml config |``
@@ -181,6 +185,6 @@ helm install --namespace puppetserver --name puppetserver ./ -f values.yaml
 
 ## Chart's Dev Team
 
-- Lead Developer: Miroslav Hadzhiev (miroslav.hadzhiev@gmail.com)
-- Developer: Scott Cressi (scottcressi@gmail.com)
-- Developer: Morgan Rhodes (morgan@puppet.com)
+* Lead Developer: Miroslav Hadzhiev (miroslav.hadzhiev@gmail.com)
+* Developer: Scott Cressi (scottcressi@gmail.com)
+* Developer: Morgan Rhodes (morgan@puppet.com)

--- a/k8s/templates/r10k-configmap.yaml
+++ b/k8s/templates/r10k-configmap.yaml
@@ -7,23 +7,61 @@ metadata:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 data:
   r10k.yaml: |
+    # The location to use for storing cached Git repos
     :cachedir: '/var/tmp/r10k_cache'
-    sources:
-      puppet:
+
+    # A list of git repositories to create
+    :sources:
+      # This will clone the git repository and instantiate an environment per
+      # branch in '/etc/puppetlabs/code/environments'
+      :puppet_repo:
         remote: '{{.Values.puppetserver.puppeturl}}'
         basedir: '/etc/puppetlabs/code/environments'
       {{- if .Values.hiera.hieradataurl }}
-      hiera:
+      # This will clone the git repository and instantiate an environment per
+      # branch in '/etc/puppetlabs/code/hiera-data'
+      :hiera_repo:
         remote: '{{.Values.hiera.hieradataurl}}'
         basedir: '/etc/puppetlabs/code/hiera-data'
       {{- end }}
-    git:
+
+    :git:
       provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
-      {{- if and (.Values.r10k.viaSsh.enabled) (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+      {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+      {{- if and (not .Values.r10k.viaSsh.repo) (not .Values.r10k.viaHttps.repo) }}
       private_key: '/root/.ssh/id_rsa'
       {{- end }}
+      {{- if (eq (.Values.r10k.viaSsh.repo | toString) "puppet_repo") (ne (.Values.r10k.viaHttps.repo | toString) "puppet_repo") }}
+      repositories:
+        - remote: '{{.Values.puppetserver.puppeturl}}'
+          private_key: '/root/.ssh/id_rsa'
+      {{- end }}
+      {{- if (eq (.Values.r10k.viaSsh.repo | toString) "hiera_repo") (ne (.Values.r10k.viaHttps.repo | toString) "hiera_repo") }}
+      repositories:
+        - remote: '{{.Values.hiera.hieradataurl}}'
+          private_key: '/root/.ssh/id_rsa'
+      {{- end }}
+      {{- end }}
       {{- if and (.Values.r10k.viaHttps.credentials.username) (.Values.r10k.viaHttps.credentials.password) }}
+      {{- if and (not .Values.r10k.viaHttps.repo) (not .Values.r10k.viaSsh.repo) }}
       username: '{{.Values.r10k.viaHttps.credentials.username}}'
       password: '{{.Values.r10k.viaHttps.credentials.password}}'
+      {{- end }}
+      {{- if and (eq (.Values.r10k.viaHttps.repo | toString) "puppet_repo") (ne (.Values.r10k.viaSsh.repo | toString) "puppet_repo") }}
+      {{- if not .Values.r10k.viaSsh.repo }}
+      repositories:
+      {{- end }}
+        - remote: '{{.Values.puppetserver.puppeturl}}'
+          username: '{{.Values.r10k.viaHttps.credentials.username}}'
+          password: '{{.Values.r10k.viaHttps.credentials.password}}'
+      {{- end }}
+      {{- if and (eq (.Values.r10k.viaHttps.repo | toString) "hiera_repo") (ne (.Values.r10k.viaSsh.repo | toString) "hiera_repo") }}
+      {{- if not .Values.r10k.viaSsh.repo }}
+      repositories:
+      {{- end }}
+        - remote: '{{.Values.hiera.hieradataurl}}'
+          username: '{{.Values.r10k.viaHttps.credentials.username}}'
+          password: '{{.Values.r10k.viaHttps.credentials.password}}'
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/k8s/templates/r10k-cronjob.yaml
+++ b/k8s/templates/r10k-cronjob.yaml
@@ -42,7 +42,7 @@ spec:
                 - {{ $value }}
               {{- end }}
               volumeMounts:
-                {{- if and (.Values.r10k.viaSsh.enabled) (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+                {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
                 - name: r10k-secret
                   mountPath: /root/.ssh
                 {{- end }}
@@ -59,7 +59,7 @@ spec:
             - name: r10k-volume
               configMap:
                 name: r10k-config
-            {{- if and (.Values.r10k.viaSsh.enabled) (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
+            {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
             - name: r10k-secret
               secret:
                 secretName: {{ template "r10k.secret" . }}

--- a/k8s/templates/r10k-secret.yaml
+++ b/k8s/templates/r10k-secret.yaml
@@ -9,11 +9,11 @@ metadata:
     {{- include "puppetserver.r10k.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.r10k.viaSsh.enabled }}
+  {{- if and (.Values.r10k.viaSsh.credentials.ssh.value) (.Values.r10k.viaSsh.credentials.known_hosts.value) }}
   id_rsa: {{ .Values.r10k.viaSsh.credentials.ssh.value | b64enc | quote }}
   known_hosts: {{ .Values.r10k.viaSsh.credentials.known_hosts.value | b64enc | quote }}
   {{- end }}
-  {{- if .Values.r10k.viaHttps.enabled }}
+  {{- if and (.Values.r10k.viaHttps.credentials.username) (.Values.r10k.viaHttps.credentials.password) }}
   username: {{ .Values.r10k.viaHttps.credentials.username | b64enc | quote }}
   password: {{ .Values.r10k.viaHttps.credentials.password | b64enc | quote }}
   {{- end }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -7,7 +7,7 @@
 puppetserver:
   name: puppetserver
   image: puppet/puppetserver
-  tag: 6.7.1
+  tag: 6.7.2
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -84,18 +84,19 @@ r10k:
   #    memory: 512Mi
   #    cpu: 500m
   cronJob:
-    schedule: "*/2 * * * *"
+    schedule: "*/5 * * * *"
   ## Additional r10k container arguments
-  extraArgs: {}
+  extraArgs:
   #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
   #  - --trace
   #  - --color
   ## Additional puppetserver container environment variables
   extraEnv: {}
-  ## Cloning via HTTPS method and its creds (if a private repo)
+  ## Cloning via HTTPS protocol with authentication
   ##
   viaHttps:
-    enabled: true
+    ## Leave empty - if HTTPS should be used for both - Puppet and Hiera repos.
+    repo: ""   # "puppet_repo" or "hiera_repo"
     credentials:
       username: ""
       ## The password might be your user-generated token
@@ -103,10 +104,11 @@ r10k:
       password: ""
       ## Or set the "username" and "password" from a pre-existing K8s secret
       existingSecret: ""
-  ## Cloning via SSH method and its creds
+  ## Cloning via SSH protocol with authentication
   ##
   viaSsh:
-    enabled: false
+    ## Leave empty - if SSH should be used for both - Puppet and Hiera repos.
+    repo: ""   # "puppet_repo" or "hiera_repo"
     credentials:
       ssh:
         ## A multi-line string

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -86,7 +86,7 @@ r10k:
   cronJob:
     schedule: "*/5 * * * *"
   ## Additional r10k container arguments
-  extraArgs:
+  extraArgs: {}
   #  - --verbose=debug2   # error, warn, notice, info, debug, debug1, debug2
   #  - --trace
   #  - --color


### PR DESCRIPTION
- [Firewall Related] Add support for separate r10k network protocols to gather the code of Puppet and Hiera repos.
- Increase default r10k sync runtime interval to every 5 minutes.
- Syntax improvements.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.2.2...v1.3.1)
