### PR TITLE
Chart v1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To get started, you will need an installation of
 [Docker Compose](https://docs.docker.com/compose/install/) on the host on
 which you will run your Puppet Infrastructure.
 
-Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed.
+Running Puppet Infrastructure in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed.
 
 We've been developing our own Helm chart which can get you up & running fast. You can find it [here](k8s). We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to make use of it by just adding the repo in your configured Helm repos.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ which you will run your Puppet Infrastructure.
 Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed.
 
 We have our own Helm chart which can get you up & running fast. You can find it [here](k8s).
-We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to deploy it by just adding the repo in your configured Helm repos.
+We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to make use of it by just adding the repo in your configured Helm repos.
 
 ## Required versions
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ To get started, you will need an installation of
 [Docker Compose](https://docs.docker.com/compose/install/) on the host on
 which you will run your Puppet Infrastructure.
 
-Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed. We have our own Helm chart which can get you up & running fast. You can find it [here](k8s).
+Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed.
+
+We have our own Helm chart which can get you up & running fast. You can find it [here](k8s).
+We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to deploy it by just adding the repo in your configured Helm repos.
 
 ## Required versions
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ which you will run your Puppet Infrastructure.
 
 Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed.
 
-We have our own Helm chart which can get you up & running fast. You can find it [here](k8s).
-We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to make use of it by just adding the repo in your configured Helm repos.
+We've been developing our own Helm chart which can get you up & running fast. You can find it [here](k8s). We have a plan to start hosting it soon as a Helm chart and publish it in the fantastic [Helm Hub](https://hub.helm.sh/). The latter will allow you to make use of it by just adding the repo in your configured Helm repos.
 
 ## Required versions
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ To get started, you will need an installation of
 [Docker Compose](https://docs.docker.com/compose/install/) on the host on
 which you will run your Puppet Infrastructure.
 
+Running Puppet in [Kubernetes](https://kubernetes.io/) is also a very viable option. To get started with that, you will need a running K8s cluster with [Helm](https://helm.sh/) deployed. We have our own Helm chart which can get you up & running fast. You can find it [here](k8s).
+
 ## Required versions
 
 * Docker Compose - must support `version: '3'` of the compose file format, which requires Docker Engine `1.13.0+`. [Full compatibility matrix](https://docs.docker.com/compose/compose-file/compose-versioning/)

--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.5.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.5.3) (2019-12-09)
+
+- Small README fixes.
+- Add information about the chart in the main [README.md](https://github.com/puppetlabs/pupperware/blob/master/README.md) of Puppetlabs's Pupperware repo.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.5.2...v1.5.3)
+
 ## [v1.5.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.5.2) (2019-12-06)
 
 - Fix PuppetDB usage of pre-generated Puppet SSL certs.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Puppet automates the delivery and operation of software.
 name: puppetserver
-version: 1.5.2
+version: 1.5.3
 appVersion: 6.7.2
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -143,7 +143,7 @@ job.batch/puppetserver-r10k-code-deploy-1575237600   1/1           2s         10
 job.batch/puppetserver-r10k-code-deploy-1575238200   1/1           2s         39s
 
 NAME                                          SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
-cronjob.batch/puppetserver-r10k-code-deploy   */10 * * * *   False     0        42s             24m
+cronjob.batch/puppetserver-r10k-code-deploy   */15 * * * *   False     0        42s             24m
 ```
 
 ## Configuration

--- a/k8s/init/README.md
+++ b/k8s/init/README.md
@@ -2,4 +2,4 @@
 
 Please archive the contents of your `/etc/puppetlabs/puppet/ssl/*` of your bare-metal Puppet Server master and `/opt/puppetlabs/server/data/puppetdb/certs/*` of your bare-metal PuppetDB instance into two separate `.gz` files and place them respectively into the `puppet-certs/puppetserver` and `puppet-certs/puppetdb` directories.
 
-> **NOTE**: Please keep only your archive files in each `puppet-certs/` dir.
+> **NOTE**: Please keep only your archive files in each `puppet-certs/` subdir.


### PR DESCRIPTION
## [v1.5.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.5.3) (2019-12-09)

- Small README fixes.
- Add information about the chart in the main [README.md](https://github.com/puppetlabs/pupperware/blob/master/README.md) of Puppetlabs's Pupperware repo.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.5.2...v1.5.3)
