### PR TITLE
Add Optional Affinity for "r10k" Pod Assignment. Security Fixes.

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,14 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.6.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.6.0) (2019-12-26)
+
+- Add optional affinity for "r10k" pod assignment.
+- File permission fixes for "r10k" jobs' SSH keys.
+- Security fixes for the "r10k" jobs.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.5.3...v1.6.0)
+
 ## [v1.5.3](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.5.3) (2019-12-09)
 
 - Small README fixes.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -176,6 +176,7 @@ Parameter | Description | Default
 `r10k.image` | r10k img | `puppet/r10k`
 `r10k.tag` | r10k img tag | `3.3.3`
 `r10k.pullPolicy` | r10k img pull policy | `IfNotPresent`
+`r10k.affinity` | r10k pod assignment affinity |``
 `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`
 `r10k.code.cronJob.concurrencyPolicy` | r10k control repo cron job concurrency policy | `Forbid`
 `r10k.code.cronJob.restartPolicy` | r10k control repo cron job restart policy | `Never`

--- a/k8s/templates/r10k-code.configmap.yaml
+++ b/k8s/templates/r10k-code.configmap.yaml
@@ -20,7 +20,7 @@ data:
       provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
     {{- with .Values.r10k.code.viaSsh.credentials }}
     {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-      private_key: '/root/.ssh/id_rsa'
+      private_key: '/home/puppet/.ssh/id_rsa'
     {{- end }}
     {{- end }}
       repositories:

--- a/k8s/templates/r10k-code.cronjob.yaml
+++ b/k8s/templates/r10k-code.cronjob.yaml
@@ -53,7 +53,7 @@ spec:
               {{- with .Values.r10k.code.viaSsh.credentials }}
               {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
                 - name: r10k-code-secret
-                  mountPath: /root/.ssh
+                  mountPath: /home/puppet/.ssh
               {{- end }}
               {{- end }}
                 - name: r10k-volume
@@ -61,6 +61,9 @@ spec:
                   subPath: r10k.yaml
                 - name: puppet-code-storage
                   mountPath: /etc/puppetlabs/code/
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            fsGroup: 999   # "puppet" GID
         {{- with .Values.r10k.code.cronJob }}
         {{- if .restartPolicy }}
           restartPolicy: {{ .restartPolicy }}
@@ -81,6 +84,7 @@ spec:
               secret:
                 secretName: {{ template "r10k.code.secret" . }}
                 defaultMode: 288 # = mode 0440
+                fsGroup: 999   # "puppet" GID
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:
@@ -91,7 +95,10 @@ spec:
             {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.affinity }}
+        {{- if .Values.r10k.affinity }}
+          affinity:
+            {{ toYaml .Values.r10k.affinity | nindent 14 }}
+        {{- else if .Values.affinity }}
           affinity:
             {{ toYaml .Values.affinity | nindent 14 }}
         {{- end }}

--- a/k8s/templates/r10k-hiera.configmap.yaml
+++ b/k8s/templates/r10k-hiera.configmap.yaml
@@ -22,7 +22,7 @@ data:
       provider: 'rugged' # Either 'shellgit' or 'rugged', defaults to 'shellgit'
     {{- with .Values.r10k.hiera.viaSsh.credentials }}
     {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
-      private_key: '/root/.ssh/id_rsa'
+      private_key: '/home/puppet/.ssh/id_rsa'
     {{- end }}
     {{- end }}
       repositories:

--- a/k8s/templates/r10k-hiera.cronjob.yaml
+++ b/k8s/templates/r10k-hiera.cronjob.yaml
@@ -53,7 +53,7 @@ spec:
               {{- with .Values.r10k.hiera.viaSsh.credentials }}
               {{- if or (.existingSecret) (and (.ssh.value) (.known_hosts.value)) }}
                 - name: r10k-hiera-secret
-                  mountPath: /root/.ssh
+                  mountPath: /home/puppet/.ssh
               {{- end }}
               {{- end }}
                 - name: r10k-volume
@@ -61,6 +61,9 @@ spec:
                   subPath: r10k.yaml
                 - name: puppet-code-storage
                   mountPath: /etc/puppetlabs/code/
+          securityContext:
+            runAsUser: 999   # "puppet" UID
+            fsGroup: 999   # "puppet" GID
         {{- with .Values.r10k.hiera.cronJob }}
         {{- if .restartPolicy }}
           restartPolicy: {{ .restartPolicy }}
@@ -81,6 +84,7 @@ spec:
               secret:
                 secretName: {{ template "r10k.hiera.secret" . }}
                 defaultMode: 288 # = mode 0440
+                fsGroup: 999   # "puppet" GID
           {{- end }}
         {{- if (or (.Values.nodeSelector.allPods) (.Values.nodeSelector.commonStoragePods)) }}
           nodeSelector:
@@ -91,7 +95,10 @@ spec:
             {{ toYaml .Values.nodeSelector.commonStoragePods | nindent 14 }}
           {{- end }}
         {{- end }}
-        {{- if .Values.affinity }}
+        {{- if .Values.r10k.affinity }}
+          affinity:
+            {{ toYaml .Values.r10k.affinity | nindent 14 }}
+        {{- else if .Values.affinity }}
           affinity:
             {{ toYaml .Values.affinity | nindent 14 }}
         {{- end }}

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -81,6 +81,25 @@ r10k:
   image: puppet/r10k
   tag: 3.3.3
   pullPolicy: IfNotPresent
+  ## Affinity for "r10k" pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note that the "puppetserver" and "r10k" components of the Puppet Server
+  ## use common storage. That common storage requirement might impose
+  ## certain pod assignment scenarios. It might be required the "puppetserver" and "r10k"
+  ## components to sit in the same K8s Node.
+  ## For that matter optional pod affinity is made available for the "r10k" pod if need be.
+  ## The exemplary configuration can be used without modification,
+  ## if "Values.puppetserver.name" is kept unchanged.
+  affinity: {}
+  #  podAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #    - labelSelector:
+  #        matchExpressions:
+  #        - key: component
+  #          operator: In
+  #          values:
+  #          - puppetserver
+  #      topologyKey: "kubernetes.io/hostname"
   code:
     resources: {}
     #  requests:


### PR DESCRIPTION
- Add optional affinity for "r10k" pod assignment.
- File permission fixes for "r10k" jobs' SSH keys.
- Security fixes for the "r10k" jobs.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.5.3...v1.6.0)