### PR TITLE
Improve `Chart.yaml`. Bump Components' Version. Minor Fixes.

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,13 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.7.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.7.1) (2020-02-01)
+
+- Improve `Chart.yaml`.
+- Bump default versions: Puppetserver to `6.8.0`, PostgreSQL to `9.6.16` and PuppetDB to `6.8.1`.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.7.0...v1.7.1)
+
 ## [v1.7.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.7.0) (2020-01-27)
 
 - Add support for multiple Puppet Compile Masters.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-description: Puppet automates the delivery and operation of software.
 name: puppetserver-helm-chart
-version: 1.7.0
-appVersion: 6.7.2
+version: 1.7.1
+appVersion: 6.8.0
+description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/
 icon: https://secure.gravatar.com/avatar/fdd009b7c1ec96e088b389f773e87aec.jpg?s=80&r=g&d=mm

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -162,15 +162,15 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `puppetserver.name` | puppetserver component label | `puppetserver`
 `puppetserver.image` | puppetserver image | `puppet/puppetserver`
-`puppetserver.tag` | puppetserver img tag | `6.7.2`
+`puppetserver.tag` | puppetserver img tag | `6.8.0`
 `puppetserver.resources` | puppetserver resource limits | ``
 `puppetserver.extraEnv` | puppetserver additional container env vars |``
 `puppetserver.preGeneratedCertsJob.enabled` | puppetserver pre-generated certs |`false`
 `puppetserver.preGeneratedCertsJob.jobDeadline` | puppetserver pre-generated certs job deadline in seconds |`60`
 `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`
-`puppetserver.multiCompilers.enabled` | If true, creates multiple Puppetserver compilers | false
+`puppetserver.multiCompilers.enabled` | If true, creates multiple Puppetserver compilers | `false`
 `puppetserver.multiCompilers.manualScaling.compilers` | If multiple compilers are enabled, this field sets compiler count | `3`
-`puppetserver.multiCompilers.autoScaling.enabled` | If true, creates Horizontal Pod Autoscaler | false
+`puppetserver.multiCompilers.autoScaling.enabled` | If true, creates Horizontal Pod Autoscaler | `false`
 `puppetserver.multiCompilers.autoScaling.minCompilers` | If autoscaling enabled, this field sets minimum compiler count | `2`
 `puppetserver.multiCompilers.autoScaling.maxCompilers` | If autoscaling enabled, this field sets maximum compiler count | `11`
 `puppetserver.multiCompilers.autoScaling.cpuUtilizationPercentage` | Target CPU utilization percentage to scale | `50`
@@ -216,13 +216,13 @@ Parameter | Description | Default
 `r10k.hiera.viaSsh.credentials.existingSecret`| r10k hiera data ssh secret that holds ssh key and known hosts files |``
 `postgres.name` | postgres component label | `postgres`
 `postgres.image` | postgres img | `postgres`
-`postgres.tag` | postgres img tag | `9.6.15`
+`postgres.tag` | postgres img tag | `9.6.16`
 `postgres.pullPolicy` | postgres img pull policy | `IfNotPresent`
 `postgres.resources` | postgres resource limits |``
 `postgres.extraEnv` | postgres additional container env vars |``
 `puppetdb.name` | puppetdb component label | `puppetdb`
 `puppetdb.image` | puppetdb img | `puppet/puppetdb`
-`puppetdb.tag` | puppetdb img tag | `6.7.3`
+`puppetdb.tag` | puppetdb img tag | `6.8.1`
 `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`
 `puppetdb.resources` | puppetdb resource limits |``
 `puppetdb.extraEnv` | puppetdb additional container env vars |``

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -7,12 +7,12 @@
 puppetserver:
   name: puppetserver
   image: puppet/puppetserver
-  tag: 6.7.2
+  tag: 6.8.0
   pullPolicy: IfNotPresent
   ## Horizontal Scaling
   ## Optional deployment of multiple Puppet Server Compilers
   multiCompilers:
-    enabled: true
+    enabled: false
     ## Horizontal Pod Manual Scaling
     ## Set the desired number of Puppet Server Compilers
     manualScaling:
@@ -205,7 +205,7 @@ r10k:
 postgres:
   name: postgres
   image: postgres
-  tag: 9.6.15
+  tag: 9.6.16
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -225,7 +225,7 @@ postgres:
 puppetdb:
   name: puppetdb
   image: puppet/puppetdb
-  tag: 6.8.0
+  tag: 6.8.1
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:


### PR DESCRIPTION
- Improve `Chart.yaml`.
- Bump default versions: Puppetserver to `6.8.0`, PostgreSQL to `9.6.16` and PuppetDB to `6.8.1`.
- Minor fixes.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.7.0...v1.7.1)
