### PR TITLE
Add Chart v1.8.1

### DIFF
--- a/k8s/CHANGELOG.md
+++ b/k8s/CHANGELOG.md
@@ -5,6 +5,19 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v1.8.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.8.1) (2020-03-21)
+
+- Fix auto-scaling of Puppetserver.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.8.0...v1.8.1)
+
+## [v1.8.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.8.0) (2020-03-13)
+
+- Better distinction between storage selectors.
+- Bump default versions: Puppetserver to `6.9.0` and PuppetDB to `6.9.0`.
+
+[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.7.2...v1.8.0)
+
 ## [v1.7.2](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.7.2) (2020-02-11)
 
 - Improve further `Chart.yaml`.

--- a/k8s/Chart.yaml
+++ b/k8s/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: puppetserver-helm-chart
-version: 1.7.2
-appVersion: 6.8.0
+version: 1.8.1
+appVersion: 6.9.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -228,8 +228,7 @@ Parameter | Description | Default
 `puppetdb.extraEnv` | puppetdb additional container env vars |``
 `puppetdb.credentials.username`| puppetdb username |`puppetdb`
 `puppetdb.credentials.value.password`| puppetdb password |`20-char randomly generated`
-`puppetdb.credentials.password.existingSecret`| k8s secret that holds puppetdb password |``
-`puppetdb.credentials.password.existingSecretKey`| k8s secret key that holds puppetdb password |``
+`puppetdb.credentials.existingSecret`| existing k8s secret that holds puppetdb username and password |``
 `puppetboard.enabled` | puppetboard availability | `false`
 `puppetboard.name` | puppetboard component label | `puppetboard`
 `puppetboard.image` | puppetboard img | `puppet/puppetboard`

--- a/k8s/templates/_helpers.tpl
+++ b/k8s/templates/_helpers.tpl
@@ -108,6 +108,16 @@ component: {{ .Values.puppetserver.name | quote }}
 {{ include "puppetserver.common.matchLabels" . }}
 {{- end -}}
 
+{{- define "puppetserver.puppetserver-data.labels" -}}
+{{ include "puppetserver.puppetserver-data.matchLabels" . }}
+{{ include "puppetserver.common.metaLabels" . }}
+{{- end -}}
+
+{{- define "puppetserver.puppetserver-data.matchLabels" -}}
+component: "{{ .Values.puppetserver.name}}-serverdata"
+{{ include "puppetserver.common.matchLabels" . }}
+{{- end -}}
+
 {{/*
 Set mandatory Puppet Server Service name.
 */}}

--- a/k8s/templates/puppetserver-code-pvc.yaml
+++ b/k8s/templates/puppetserver-code-pvc.yaml
@@ -12,7 +12,7 @@ spec:
 {{- if .Values.storage.selector }}
   selector:
     matchLabels:
-      {{- include "puppetserver.puppetserver.matchLabels" . | nindent 6 }}
+      {{- include "puppetserver.r10k.matchLabels" . | nindent 6 }}
 {{- end }}
   accessModes:
     - ReadWriteOnce

--- a/k8s/templates/puppetserver-data-pvc.yaml
+++ b/k8s/templates/puppetserver-data-pvc.yaml
@@ -12,7 +12,7 @@ spec:
 {{- if .Values.storage.selector }}
   selector:
     matchLabels:
-      {{- include "puppetserver.puppetserver.matchLabels" . | nindent 6 }}
+      {{- include "puppetserver.puppetserver-data.matchLabels" . | nindent 6 }}
 {{- end }}
   accessModes:
     - ReadWriteOnce

--- a/k8s/templates/puppetserver-deployment.yaml
+++ b/k8s/templates/puppetserver-deployment.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
 spec:
   {{- if .Values.puppetserver.multiCompilers.enabled }}
+  {{- if not (.Values.puppetserver.multiCompilers.autoScaling.enabled) }}
   replicas: {{ .Values.puppetserver.multiCompilers.manualScaling.compilers }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -7,7 +7,7 @@
 puppetserver:
   name: puppetserver
   image: puppet/puppetserver
-  tag: 6.8.0
+  tag: 6.9.0
   pullPolicy: IfNotPresent
   ## Horizontal Scaling
   ## Optional deployment of multiple Puppet Server Compilers
@@ -219,7 +219,7 @@ postgres:
 puppetdb:
   name: puppetdb
   image: puppet/puppetdb
-  tag: 6.8.1
+  tag: 6.9.0
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -236,9 +236,10 @@ puppetdb:
     ## Override the 20-char random "password" in templates/puppetdb-secret.yaml
     password:
       value: ""
-      ## Or set the PuppetDB password from a pre-existing K8s secret
-      existingSecret: ""
-      existingSecretKey: ""
+    # if used, the following existing secret must contain "username" and "password" keys, already base64 encoded.
+    # using this secret supercedes all other credentials settings.
+    existingSecret: ""
+
 
 ## Puppetboard Configuration
 ##


### PR DESCRIPTION
## [v1.8.1](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.8.1) (2020-03-21)

- Fix auto-scaling of Puppetserver.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.8.0...v1.8.1)

## [v1.8.0](https://github.com/Xtigyro/puppetserver-helm-chart/tree/v1.8.0) (2020-03-13)

- Better distinction between storage selectors.
- Bump default versions: Puppetserver to `6.9.0` and PuppetDB to `6.9.0`.

[Full Changelog](https://github.com/Xtigyro/puppetserver-helm-chart/compare/v1.7.2...v1.8.0)
