### PR TITLE
(maint) Remove curl dependency from shared ssl.sh

### DIFF
--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -30,6 +30,7 @@
 #   WAITFORCERT            Number of seconds to wait for certificate to be
 #                          signed, defaults to 120
 #   PUPPETSERVER_HOSTNAME  Hostname of Puppet Server CA, defaults to "puppet"
+#   PUPPETSERVER_PORT      Port of Puppet Server CA, defaults to 8140
 #   SSLDIR                 Root directory to write files to, defaults to
 #                          "/etc/puppetlabs/puppet/ssl"
 #   DNS_ALT_NAMES          Comma-separated string of DNS subject alternative
@@ -53,6 +54,7 @@ error() {
 CERTNAME="${1:-${CERTNAME:-${HOSTNAME}}}"
 [ -z "${CERTNAME}" ] && error "certificate name must be non-empty value"
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
+PUPPETSERVER_PORT="${PUPPETSERVER_PORT:-8140}"
 SSLDIR="${SSLDIR:-/etc/puppetlabs/puppet/ssl}"
 WAITFORCERT=${WAITFORCERT:-120}
 DNS_ALT_NAMES=${DNS_ALT_NAMES}
@@ -70,7 +72,7 @@ CERTFILE="${CERTDIR}/${CERTNAME}.pem"
 CACERTFILE="${CERTDIR}/ca.pem"
 CRLFILE="${SSLDIR}/crl.pem"
 
-CA="https://${PUPPETSERVER_HOSTNAME}:8140/puppet-ca/v1"
+CA="https://${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}/puppet-ca/v1"
 CERTSUBJECT="/CN=${CERTNAME}"
 CERTHEADER="-----BEGIN CERTIFICATE-----"
 CURLFLAGS="--silent --show-error --cacert ${CACERTFILE} --retry 5 --retry-connrefused --retry-delay 2"

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -68,7 +68,14 @@ httpsreq_insecure() {
     CLIENTFLAGS="-connect ""${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}"" -ign_eof -quiet $2"
 
     # shellcheck disable=SC2086 # $CLIENTFLAGS shouldn't be quoted
-    response=$(printf "%s\n\n" "$1" | openssl s_client ${CLIENTFLAGS} 2>/dev/null)
+    if ! response=$(printf "%s\n\n" "$1" | openssl s_client ${CLIENTFLAGS} 2>/dev/null); then
+        # possibly due to DNS errors or connnection refused
+        return 1
+    fi
+
+    # an empty response doesn't include a status code, so abort
+    [ -z "$response" ] && return 1
+
     # extract the HTTP status code from first line of response
     # RFC2616 defines first line header as Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
     status=$(printf "%s" "$response" | head -1 | cut -d ' ' -f 2)
@@ -163,23 +170,22 @@ done
 
 ### Get the CA certificate for use with subsequent requests
 ### Fail-fast if openssl errors connecting or the CA certificate can't be parsed
-httpsreq_insecure "$(get "${CA}/certificate/ca")" > "${CACERTFILE}"
-if [ $? -ne 0 ]; then
+if ! httpsreq_insecure "$(get "${CA}/certificate/ca")" > "${CACERTFILE}"; then
     error "cannot reach CA host '${PUPPETSERVER_HOSTNAME}'"
 elif ! openssl x509 -subject -issuer -noout -in "${CACERTFILE}"; then
     error "invalid CA certificate"
 fi
 
 ### Get the CRL from the CA for use with client-side validation
-httpsreq "$(get "${CA}/certificate_revocation_list/ca")" > "${CRLFILE}"
-if ! openssl crl -text -noout -in "${CRLFILE}" > /dev/null; then
+if ! httpsreq "$(get "${CA}/certificate_revocation_list/ca")" > "${CRLFILE}"; then
+    error "cannot reach CRL host '${PUPPETSERVER_HOSTNAME}'"
+elif ! openssl crl -text -noout -in "${CRLFILE}" > /dev/null; then
     error "invalid CRL"
 fi
 
 ### Check the CA does not already have a signed certificate for this host
 CERTREQ=$(get "${CA}/certificate/${CERTNAME}")
-httpsreq "$CERTREQ" >/dev/null
-if [ $? -eq 0 ]; then
+if httpsreq "$CERTREQ" >/dev/null; then
     error "CA already has signed certificate for '${CERTNAME}'"
 fi
 
@@ -203,8 +209,7 @@ $(cat "${CSRFILE}")
 EOF
 )
 
-output=$(httpsreq "$CSRREQ")
-if [ $? -ne 0 ]; then
+if ! output=$(httpsreq "$CSRREQ"); then
     cert_already_exists="${CERTNAME} already has a requested certificate; ignoring certificate request"
     altnames_disallowed="CSR '${CERTNAME}' contains subject alternative names*which are disallowed*"
     # shellcheck disable=SC2254 # string contains * used for globbing
@@ -218,14 +223,12 @@ fi
 ### Retrieve signed certificate; wait and try again with a timeout
 sleeptime=10
 timewaited=0
-cert=$(httpsreq "$CERTREQ")
-while [ $? -ne 0 ]; do
+while ! cert=$(httpsreq "$CERTREQ"); do
     [ ${timewaited} -ge $((WAITFORCERT)) ] && \
         error "timed-out waiting for certificate to be signed"
     msg "Waiting for certificate to be signed..."
     sleep ${sleeptime}
     timewaited=$((timewaited+sleeptime))
-    cert=$(httpsreq "$CERTREQ")
 done
 printf "%s\n" "${cert}" > "${CERTFILE}"
 

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -79,9 +79,12 @@ httpsreq_insecure() {
     body=false
     printf "%s\n" "$response" | while read -r line
     do
-      [ $body = true ] && printf '%s\n' "$line"
-      # a lone CR means the separator between headers and body has been reached
-      [ "$line" = "$(printf "\r")" ] && body=true
+        if [ $body = true ]; then
+            printf '%s\n' "$line"
+        # a lone CR means the separator between headers and body has been reached
+        elif [ "$line" = "$(printf "\r")" ]; then
+            body=true
+        fi
     done
 
     # treat a 200 as 0 exit code

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -2,14 +2,15 @@
 #
 # Get a signed certificate for this host.
 #
-# Uses OpenSSL and curl directly to generate a new CSR and get it signed by the
+# Uses OpenSSL directly to generate a new CSR and get it signed by the
 # Puppet Server CA.
 #
 # Intended to be used in place of a full-blown puppet agent run that is solely
 # for getting SSL certificates onto the host.
 #
 # Files will be placed in the same default directory location and structure
-# that the puppet agent would put them, which is /etc/puppetlabs/puppet/ssl.
+# that the puppet agent would put them, which is /etc/puppetlabs/puppet/ssl,
+# unless the SSLDIR environment variable is specified.
 #
 # The certname can be provided as the first argument to this script, or
 # as the CERTNAME environment variable. If both are found, the argument
@@ -45,15 +46,49 @@ error() {
     exit 1
 }
 
+# builds the GET http request given a URI
+get() {
+    printf "GET %s HTTP/1.0\n%s\n\n" "$1" "$HOSTHEADER"
+}
+
+# use openssl s_client to create HTTP requests and parse the response
+# a 200 OK will set a 0 return value, all other responses are non-zero
+# the HTTP response body is returned over stdout
+# $1 is request value
+httpsreq() {
+    CLIENTFLAGS="-connect ""${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}"" -ign_eof -quiet -CAfile ""${CACERTFILE}"""
+
+    # shellcheck disable=SC2086 # $CLIENTFLAGS shouldn't be quoted
+    response=$(echo "$1" | openssl s_client ${CLIENTFLAGS} 2>/dev/null)
+    # extract the HTTP status code from first line of response
+    # RFC2616 defines first line header as Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
+    status=$(echo "$response" | head -1 | cut -d ' ' -f 2)
+
+    # write HTTP payload over stdout by collecting all lines after header\r
+    # same as: awk -v bl=1 'bl{bl=0; h=($0 ~ /HTTP\/1/)} /^\r?$/{bl=1} {if(!h) print}'
+    body=false
+    echo "${response}" | while read -r line
+    do
+      [ $body = true ] && printf '%s\n' "$line"
+      # a lone CR means the separator between headers and body has been reached
+      [ "$line" = "$(printf "\r")" ] && body=true
+    done
+
+    # treat a 200 as 0 exit code
+    [ "${status}" = "200" ] && return 0 || return "$((status))"
+}
+
 master_running() {
-    status=$(curl --silent --fail --insecure \
-        "https://${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}/status/v1/simple")
+    status=$(printf "%s" "$(get '/status/v1/simple')" | \
+        openssl s_client -connect "${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}" -ign_eof -quiet 2>/dev/null | \
+        awk -v bl=1 'bl{bl=0; h=($0 ~ /HTTP\/1/)} /^\r?$/{bl=1} {if(!h) print}'
+    )
+
     test "$status" = "running"
 }
 
 ### Verify dependencies available
 ! command -v openssl > /dev/null && error "openssl not found on PATH"
-! command -v curl > /dev/null && error "curl not found on PATH"
 
 ### Verify options are valid
 # shellcheck disable=SC2039 # Docker injects $HOSTNAME
@@ -78,10 +113,10 @@ CERTFILE="${CERTDIR}/${CERTNAME}.pem"
 CACERTFILE="${CERTDIR}/ca.pem"
 CRLFILE="${SSLDIR}/crl.pem"
 
-CA="https://${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}/puppet-ca/v1"
+CA="/puppet-ca/v1"
 CERTSUBJECT="/CN=${CERTNAME}"
 CERTHEADER="-----BEGIN CERTIFICATE-----"
-CURLFLAGS="--silent --show-error --cacert ${CACERTFILE} --retry 5 --retry-connrefused --retry-delay 2"
+HOSTHEADER="Host: ${PUPPETSERVER_HOSTNAME}"
 
 ### Handle certificate extensions
 # NOTE If we want to expand support for more extensions, it would be better
@@ -108,7 +143,7 @@ fi
 msg "Using configuration values:"
 msg "* CERTNAME: '${CERTNAME}' (${CERTSUBJECT})"
 msg "* DNS_ALT_NAMES: '${DNS_ALT_NAMES}'"
-msg "* CA: '${CA}'"
+msg "* CA: '${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}${CA}'"
 msg "* SSLDIR: '${SSLDIR}'"
 msg "* WAITFORCERT: '${WAITFORCERT}' seconds"
 
@@ -123,8 +158,11 @@ while ! master_running; do
 done
 
 ### Get the CA certificate for use with subsequent requests
-### Fail-fast if curl errors or the CA certificate can't be parsed
-curl --insecure --silent --show-error --output "${CACERTFILE}" --retry 5 --retry-connrefused --retry-delay 2 "${CA}/certificate/ca"
+### Fail-fast if openssl errors connecting or the CA certificate can't be parsed
+printf "%s" "$(get "${CA}/certificate/ca")" | \
+    openssl s_client -connect "${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}" -ign_eof -quiet 2>/dev/null | \
+    sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' \
+    > "${CACERTFILE}"
 if [ $? -ne 0 ]; then
     error "cannot reach CA host '${PUPPETSERVER_HOSTNAME}'"
 elif ! openssl x509 -subject -issuer -noout -in "${CACERTFILE}"; then
@@ -132,14 +170,15 @@ elif ! openssl x509 -subject -issuer -noout -in "${CACERTFILE}"; then
 fi
 
 ### Get the CRL from the CA for use with client-side validation
-curl ${CURLFLAGS} --output "${CRLFILE}" "${CA}/certificate_revocation_list/ca"
+httpsreq "$(get "${CA}/certificate_revocation_list/ca")" > "${CRLFILE}"
 if ! openssl crl -text -noout -in "${CRLFILE}" > /dev/null; then
     error "invalid CRL"
 fi
 
 ### Check the CA does not already have a signed certificate for this host
-output="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
-if [ "$(echo "${output}" | head -1)" = "${CERTHEADER}" ]; then
+CERTREQ=$(get "${CA}/certificate/${CERTNAME}")
+httpsreq "$CERTREQ" >/dev/null
+if [ $? -eq 0 ]; then
     error "CA already has signed certificate for '${CERTNAME}'"
 fi
 
@@ -153,9 +192,18 @@ openssl rsa -in "${PRIVKEYFILE}" -pubout -out "${PUBKEYFILE}"
 openssl req -new -key "${PRIVKEYFILE}" -out "${CSRFILE}" -subj "${CERTSUBJECT}" ${CERTEXTENSIONS}
 
 ### Submit CSR and fail gracefully on certain error conditions
-output="$(curl ${CURLFLAGS} -X PUT -H "Content-Type: text/plain" \
-               --data-binary "@${CSRFILE}" "${CA}/certificate_request/${CERTNAME}")"
-if [ -n "${output}" ]; then
+CSRREQ=$(cat <<EOF
+PUT ${CA}/certificate_request/${CERTNAME} HTTP/1.0
+${HOSTHEADER}
+Content-Length:$(wc -c < "${CSRFILE}")
+Content-Type: text/plain
+
+$(cat "${CSRFILE}")
+EOF
+)
+
+output=$(httpsreq "$CSRREQ")
+if [ $? -ne 0 ]; then
     cert_already_exists="${CERTNAME} already has a requested certificate; ignoring certificate request"
     altnames_disallowed="CSR '${CERTNAME}' contains subject alternative names*which are disallowed*"
     # shellcheck disable=SC2254 # string contains * used for globbing
@@ -169,14 +217,14 @@ fi
 ### Retrieve signed certificate; wait and try again with a timeout
 sleeptime=10
 timewaited=0
-cert="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
-while [ "$(echo "${cert}" | head -1)" != "${CERTHEADER}" ]; do
+cert=$(httpsreq "$CERTREQ")
+while [ $? -ne 0 ]; do
     [ ${timewaited} -ge $((WAITFORCERT)) ] && \
         error "timed-out waiting for certificate to be signed"
     msg "Waiting for certificate to be signed..."
     sleep ${sleeptime}
     timewaited=$((timewaited+sleeptime))
-    cert="$(curl ${CURLFLAGS} "${CA}/certificate/${CERTNAME}")"
+    cert=$(httpsreq "$CERTREQ")
 done
 echo "${cert}" > "${CERTFILE}"
 

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -12,9 +12,7 @@
 # that the puppet agent would put them, which is /etc/puppetlabs/puppet/ssl,
 # unless the SSLDIR environment variable is specified.
 #
-# The certname can be provided as the first argument to this script, or
-# as the CERTNAME environment variable. If both are found, the argument
-# takes precedence over the environment variable. If neither are found,
+# The certname is provided as the CERTNAME environment variable. If not found,
 # the HOSTNAME will be used.
 #
 # Supports DNS alt names via the DNS_ALT_NAMES environment variable, which
@@ -22,12 +20,8 @@
 # to allow subject alt names, by default it will reject certificate requests
 # with them.
 #
-# Arguments:
-#   $1  (Optional) Certname to use. Overrides the CERTNAME environment variable.
-#                  If neither are set, the $HOSTNAME will be used.
-#
 # Optional environment variables:
-#   CERTNAME               Certname to use, unless an argument is passed in
+#   CERTNAME               Certname to use
 #   WAITFORCERT            Number of seconds to wait for certificate to be
 #                          signed, defaults to 120
 #   PUPPETSERVER_HOSTNAME  Hostname of Puppet Server CA, defaults to "puppet"
@@ -103,7 +97,7 @@ master_running() {
 
 ### Verify options are valid
 # shellcheck disable=SC2039 # Docker injects $HOSTNAME
-CERTNAME="${1:-${CERTNAME:-${HOSTNAME}}}"
+CERTNAME="${CERTNAME:-${HOSTNAME}}"
 [ -z "${CERTNAME}" ] && error "certificate name must be non-empty value"
 PUPPETSERVER_HOSTNAME="${PUPPETSERVER_HOSTNAME:-puppet}"
 PUPPETSERVER_PORT="${PUPPETSERVER_PORT:-8140}"
@@ -152,6 +146,9 @@ fi
 
 ### Print configuration for troubleshooting
 msg "Using configuration values:"
+# shellcheck disable=SC2039 # Docker injects $HOSTNAME
+msg "* HOSTNAME: '${HOSTNAME}'"
+msg "* hostname -f: '$(hostname -f)'"
 msg "* CERTNAME: '${CERTNAME}' (${CERTSUBJECT})"
 msg "* DNS_ALT_NAMES: '${DNS_ALT_NAMES}'"
 msg "* CA: '${PUPPETSERVER_HOSTNAME}:${PUPPETSERVER_PORT}${CA}'"

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -120,6 +120,7 @@ CSRFILE="${CSRDIR}/${CERTNAME}.pem"
 CERTFILE="${CERTDIR}/${CERTNAME}.pem"
 CACERTFILE="${CERTDIR}/ca.pem"
 CRLFILE="${SSLDIR}/crl.pem"
+ALTNAMEFILE="/tmp/altnames.conf"
 
 CA="/puppet-ca/v1"
 CERTSUBJECT="/CN=${CERTNAME}"
@@ -144,7 +145,12 @@ if [ -n "${DNS_ALT_NAMES}" ]; then
             names="${names},DNS:${name}"
         fi
     done
-    CERTEXTENSIONS="-addext subjectAltName=${names}"
+
+    # openssl 1.1.1+ supports -addext subjectAltName=${names}
+    # but Postgres 9.6 image uses openssl 1.1.0 and has no such flag, so have to use -config
+    printf "[req]\ndistinguished_name=dn\nreq_extensions=ext\n[dn]\n[ext]\nsubjectAltName=%s\n" "${names}" > "${ALTNAMEFILE}"
+
+    CERTEXTENSIONS="-config ${ALTNAMEFILE}"
 fi
 
 ### Print configuration for troubleshooting
@@ -197,6 +203,7 @@ openssl genrsa -out "${PRIVKEYFILE}" 4096
 openssl rsa -in "${PRIVKEYFILE}" -pubout -out "${PUBKEYFILE}"
 # shellcheck disable=SC2086 # $CERTEXTENSIONS shouldn't be quoted
 openssl req -new -key "${PRIVKEYFILE}" -out "${CSRFILE}" -subj "${CERTSUBJECT}" ${CERTEXTENSIONS}
+[ -f "${ALTNAMEFILE}" ] && rm "${ALTNAMEFILE}"
 
 ### Submit CSR and fail gracefully on certain error conditions
 CSRREQ=$(cat <<EOF
@@ -234,7 +241,9 @@ printf "%s\n" "${cert}" > "${CERTFILE}"
 
 ### Verify we got a signed certificate
 if [ -f "${CERTFILE}" ] && [ "$(head -1 "${CERTFILE}")" = "${CERTHEADER}" ]; then
-    if openssl x509 -subject -issuer -noout -in "${CERTFILE}"; then
+    altnames="-certopt no_subject,no_header,no_version,no_serial,no_signame,no_validity,no_issuer,no_pubkey,no_sigdump,no_aux"
+    # shellcheck disable=SC2086 # $altnames shouldn't be quoted
+    if openssl x509 -subject -issuer -text -noout -in "${CERTFILE}" $altnames; then
         msg "Successfully signed certificate '${CERTFILE}'"
     else
         error "invalid signed certificate '${CERTFILE}'"


### PR DESCRIPTION
This removes all calls to `curl`, replacing them with `openssl s_client`, which effectively removes a package dependency from any of the containers consuming this script (which should be all of them). Fewer things to ship in containers = less surface area to be concerned with.

By removing curl, we've also removed the retry behavior introduced in #64 introduced to help mitigate Docker networking bugs (specifically under LCOW). The hope is that these problems have been resolved at this point and workarounds are no longer necessary. It's very likely that this issue was related to Alpine based containers and further, it looks like LCOW may be officially dead, which makes bugs in that environment moot (we'll like into reconfiguring Windows testing under WSL or another avenue in the future). This is partially mitigated by adding the `master_running` check to the start of the script that waits for a "running" CA endpoint before attempting to generate certs.


Pipelines that have passed against the head SHA 668ea59 in this PR:

- https://github.com/puppetlabs/puppetdb/pull/3224
- https://github.com/puppetlabs/pe-puppetdb-extensions/pull/533
- https://github.com/puppetlabs/pe-bolt-vanagon/pull/59
- https://github.com/puppetlabs/pe-console-services/pull/299
- https://github.com/puppetlabs/pe-orchestration-services/pull/194

Output from container startup:

#### puppetdb

```
Running /docker-entrypoint.d/30-configure-ssl.sh
(/ssl.sh) Using configuration values:
(/ssl.sh) * HOSTNAME: 'puppetdb'
(/ssl.sh) * hostname -f: 'puppetdb'
(/ssl.sh) * CERTNAME: 'puppetdb' (/CN=puppetdb)
(/ssl.sh) * DNS_ALT_NAMES: ''
(/ssl.sh) * CA: 'puppet.test:8140/puppet-ca/v1'
(/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/puppetdb/certs'
(/ssl.sh) * WAITFORCERT: '120' seconds
(/ssl.sh) Waiting for master puppet.test to be running to generate certificates...
subject=CN = Puppet CA: puppet.test
issuer=CN = Puppet CA: puppet.test
Generating RSA private key, 4096 bit long modulus (2 primes)
......................................................................................................................................................++++
...........................................................................++++
e is 65537 (0x010001)
writing RSA key
subject=CN = puppetdb
issuer=CN = Puppet CA: puppet.test
        X509v3 extensions:
            Netscape Comment: 
                Puppet Server Internal Certificate
            X509v3 Authority Key Identifier: 
                keyid:A0:87:5F:8E:C6:BE:16:B0:17:6A:C4:10:1B:5F:97:6B:CC:FD:BB:B3

            X509v3 Subject Key Identifier: 
                4D:7D:7F:75:E4:26:3B:AE:1B:95:0E:A8:FD:59:D7:BF:05:78:33:E2
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
(/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/puppetdb/certs/certs/puppetdb.pem'
```

#### pe-puppetdb-extensions

```
Running /docker-entrypoint.d/30-configure-ssl.sh
(/ssl.sh) Using configuration values:
(/ssl.sh) * HOSTNAME: 'puppetdb.test'
(/ssl.sh) * hostname -f: 'puppetdb.test.test'
(/ssl.sh) * CERTNAME: 'pe-puppetdb' (/CN=pe-puppetdb)
(/ssl.sh) * DNS_ALT_NAMES: 'puppetdb.test,puppetdb,puppetdb.test.test,pe-puppetdb,puppetdb.test,puppetdb'
(/ssl.sh) * CA: 'puppet.test:8140/puppet-ca/v1'
(/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/puppetdb/certs'
(/ssl.sh) * WAITFORCERT: '120' seconds
(/ssl.sh) Waiting for master puppet.test to be running to generate certificates...
subject=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 03:33:26 +0000"
issuer=CN = Puppet Root CA: 0985c1742ab3fa
Generating RSA private key, 4096 bit long modulus (2 primes)
.++++
......................................++++
e is 65537 (0x010001)
writing RSA key
subject=CN = pe-puppetdb
issuer=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 03:33:26 +0000"
        X509v3 extensions:
            Netscape Comment: 
                Puppet Server Internal Certificate
            X509v3 Authority Key Identifier: 
                keyid:9D:89:A9:6A:85:91:A3:6A:5B:29:23:43:E1:B9:A9:8B:3F:B7:FB:D5

            X509v3 Subject Key Identifier: 
                00:07:D8:FF:75:A7:75:A7:1E:02:6F:11:7A:2B:84:76:DC:1D:44:01
            X509v3 Subject Alternative Name: 
                DNS:puppetdb.test, DNS:puppetdb, DNS:puppetdb.test.test, DNS:pe-puppetdb, DNS:puppetdb.test, DNS:puppetdb
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
(/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/puppetdb/certs/certs/pe-puppetdb.pem'
```

#### pe-bolt-vanagon

```
(/ssl.sh) Using configuration values:
(/ssl.sh) * HOSTNAME: 'pe-bolt-server.test'
(/ssl.sh) * hostname -f: 'pe-bolt-server.test'
(/ssl.sh) * CERTNAME: 'pe-bolt-server' (/CN=pe-bolt-server)
(/ssl.sh) * DNS_ALT_NAMES: 'pe-bolt-server.test,pe-bolt-server,pe-bolt-server.test,'
(/ssl.sh) * CA: 'puppet.test:8140/puppet-ca/v1'
(/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/bolt-server/certs'
(/ssl.sh) * WAITFORCERT: '120' seconds
(/ssl.sh) Waiting for master puppet.test to be running to generate certificates...
subject=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-07 22:59:22 +0000"
issuer=CN = Puppet Root CA: 18116a5571f56a
Generating RSA private key, 4096 bit long modulus (2 primes)
...................................................................................................................................++++
.................++++
e is 65537 (0x010001)
writing RSA key
subject=CN = pe-bolt-server
issuer=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-07 22:59:22 +0000"
        X509v3 extensions:
            Netscape Comment: 
                Puppet Server Internal Certificate
            X509v3 Authority Key Identifier: 
                keyid:37:C1:B4:D8:89:F5:B0:80:EA:F8:4C:DD:F1:32:CD:48:F3:3D:5E:D5

            X509v3 Subject Key Identifier: 
                24:A3:81:77:13:70:52:20:51:34:EB:B4:1F:26:54:75:D5:BE:C5:D5
            X509v3 Subject Alternative Name: 
                DNS:pe-bolt-server.test, DNS:pe-bolt-server, DNS:pe-bolt-server.test
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
(/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/bolt-server/certs/certs/pe-bolt-server.pem'
```

#### pe-console-services

```
Running /docker-entrypoint.d/20-setup-certs.sh
(/ssl.sh) Using configuration values:
(/ssl.sh) * HOSTNAME: 'pe-console-services.test'
(/ssl.sh) * hostname -f: 'pe-console-services.test'
(/ssl.sh) * CERTNAME: 'pe-console-services' (/CN=pe-console-services)
(/ssl.sh) * DNS_ALT_NAMES: 'pe-console-services.test,pe-console-services,pe-console-services.test,'
(/ssl.sh) * CA: 'puppet.test:8140/puppet-ca/v1'
(/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/console-services/certs'
(/ssl.sh) * WAITFORCERT: '120' seconds
(/ssl.sh) Waiting for master puppet.test to be running to generate certificates...
subject=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 19:27:51 +0000"
issuer=CN = Puppet Root CA: c01f3c989fbff5
Generating RSA private key, 4096 bit long modulus (2 primes)
.................................++++
.....................++++
e is 65537 (0x010001)
writing RSA key
subject=CN = pe-console-services
issuer=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 19:27:51 +0000"
        X509v3 extensions:
            Netscape Comment: 
                Puppet Server Internal Certificate
            X509v3 Authority Key Identifier: 
                keyid:D3:89:FC:79:06:D6:CA:4C:53:4E:B1:36:B0:4B:12:1B:1E:B5:32:8B

            X509v3 Subject Key Identifier: 
                23:9A:89:0E:39:1E:21:C1:9B:6F:94:BB:08:05:ED:E9:62:77:33:28
            X509v3 Subject Alternative Name: 
                DNS:pe-console-services.test, DNS:pe-console-services, DNS:pe-console-services.test
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
(/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/console-services/certs/certs/pe-console-services.pem'
```

### pe-orchestration-services

```
Running /docker-entrypoint.d/10-setup-certs.sh
(/ssl.sh) Using configuration values:
(/ssl.sh) * HOSTNAME: 'pe-orchestration-services.test'
(/ssl.sh) * hostname -f: 'pe-orchestration-services.test'
(/ssl.sh) * CERTNAME: 'pe-orchestration-services' (/CN=pe-orchestration-services)
(/ssl.sh) * DNS_ALT_NAMES: 'pe-orchestration-services.test,pe-orchestration-services,pe-orchestration-services.test,'
(/ssl.sh) * CA: 'puppet.test:8140/puppet-ca/v1'
(/ssl.sh) * SSLDIR: '/opt/puppetlabs/server/data/orchestration-services/certs'
(/ssl.sh) * WAITFORCERT: '120' seconds
(/ssl.sh) Waiting for master puppet.test to be running to generate certificates...
subject=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 19:23:23 +0000"
issuer=CN = Puppet Root CA: 975d8388748379
Generating RSA private key, 4096 bit long modulus (2 primes)
......................................++++
.............................................++++
e is 65537 (0x010001)
writing RSA key
subject=CN = pe-orchestration-services
issuer=CN = "Puppet Enterprise CA generated on puppet.test at 2020-04-08 19:23:23 +0000"
        X509v3 extensions:
            Netscape Comment: 
                Puppet Server Internal Certificate
            X509v3 Authority Key Identifier: 
                keyid:EB:4A:62:CF:B5:C8:72:CA:7B:62:3A:4A:8D:99:AA:6A:2B:7B:0D:3A

            X509v3 Subject Key Identifier: 
                E0:08:75:59:8E:49:8A:FF:CD:DB:69:A2:1C:31:33:1C:70:76:5A:BA
            X509v3 Subject Alternative Name: 
                DNS:pe-orchestration-services.test, DNS:pe-orchestration-services, DNS:pe-orchestration-services.test
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
(/ssl.sh) Successfully signed certificate '/opt/puppetlabs/server/data/orchestration-services/certs/certs/pe-orchestration-services.pem'
```
