### PR TITLE
(maint) Update spec helpers for latest containers, removal of .test

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -772,7 +772,7 @@ LOG
     end
   end
 
-  def wait_for_pxp_agent_to_connect(agent_name: 'puppet-agent.test', timeout: 180)
+  def wait_for_pxp_agent_to_connect(agent_name: 'puppet-agent', timeout: 180)
     generate_rbac_token()
     puts "Waiting for the puppet-agent's pxp-agent to connect to the pe-orchestration-service"
     return retry_block_up_to_timeout(timeout) do

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -640,13 +640,13 @@ LOG
   end
 
   def orchestrate_puppet_run(
-        target_agent: 'puppet-agent.test',
+        target_agent: 'puppet-agent',
         network: 'pupperware-commercial',
         rbac_username: 'admin',
         rbac_password: 'pupperware',
-        puppetserver: 'puppet.test',
-        pe_console_services: 'pe-console-services.test',
-        pe_orchestration_services: 'pe-orchestration-services.test',
+        puppetserver: 'puppet',
+        pe_console_services: 'pe-console-services',
+        pe_orchestration_services: 'pe-orchestration-services',
         image: 'artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:latest'
       )
     run_command("docker pull #{image}")

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -646,9 +646,9 @@ LOG
         rbac_password: 'pupperware',
         puppetserver: 'puppet.test',
         pe_console_services: 'pe-console-services.test',
-        pe_orchestration_services: 'pe-orchestration-services.test'
+        pe_orchestration_services: 'pe-orchestration-services.test',
+        image: 'artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:latest'
       )
-    image = 'artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:kearney-latest'
     run_command("docker pull #{image}")
     run_command("docker run \
            --rm \


### PR DESCRIPTION
 - On master branch always use `latest` instead of an older version
 - Change orchestrate_puppet_run defaults
     - Remove .test from the name of host defaults

     - This helper is only used by the pupperware-commercial repo, so the
       only impact is to older versions of the repo that didn't supply
       params to this method (i.e. this is not a problem)
 
- wait_for_pxp_agent_to_connect defaults
    - remove the .test from the end of the default test agent name
    - pe-client-tools and pupperware-commercial are the only suites using
      this helper currently