### PR TITLE
(maint) Change Lint-Dockerfile behavior

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -47,9 +47,9 @@ function Get-EnterpriseContainerVersion(
 function Lint-Dockerfile(
     $Name,
     $Path = "docker/$Name/Dockerfile",
-    $Ignore = @('DL3008','DL3018','DL4000','DL4001'))
+    $Ignore = @())
 {
-    $ignores = $Ignore | % { '--ignore', $_ }
+    $ignores = $Ignore | % { if ($_) { '--ignore', $_ } }
     Write-Host "& cmd.exe /c docker run --rm -i hadolint/hadolint hadolint $ignores -< $Path"
 
     # while a simpler method works locally, there appears to be a bug with stdin in Azure injecting BOMs?


### PR DESCRIPTION
 - Fix PowerShell Lint-Dockerfile so that when LINT_IGNORES env var is
   blank in an azure-pipelines.yml job, that we don't generate a
   `--ignore` with no values, which breaks the hadolint invocation.

 - Remove any default lint values set as individual jobs are already
   setting these to whats desirable in an individual context. These
   don't really make sense to set as defaults. The previous values, for
   reference, were:

   DL3008 - Pin versions in apt-get install
   DL3018 - Pin versions in apk add (only used on Alpine)
   DL4000 - Maintainer is deprecated
   DL4001 - Use wget or curl but not both