### PR TITLE
(maint) Disable weak DH ciphers in SSL connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,9 @@ services:
       - PUPPETSERVER_HOSTNAME=puppet
       # DNS_ALT_NAMES must be set before starting the stack the first time,
       # and must list all the names under which the puppetserver can be
-      # reached. 'puppet' must be one of them, otherwise puppetdb won't be
-      # able to get a cert. Add other names as a comma-separated list
+      # reached. Add other names as a comma-separated list
       - CA_ALLOW_SUBJECT_ALT_NAMES=true
-      - DNS_ALT_NAMES=puppet,${DNS_ALT_NAMES:-}
+      - DNS_ALT_NAMES=${DNS_ALT_NAMES:-}
       - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-true}
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
     volumes:
@@ -53,7 +52,7 @@ services:
       - PUPPETDB_POSTGRES_HOSTNAME=postgres
       - PUPPETDB_PASSWORD=puppetdb
       - PUPPETDB_USER=puppetdb
-      - DNS_ALT_NAMES=puppetdb,${DNS_ALT_NAMES:-}
+      - DNS_ALT_NAMES=${DNS_ALT_NAMES:-}
     ports:
       - 8080
       - 8081

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -107,6 +107,7 @@ module SpecHelpers
     req_options = {
       use_ssl: uri.scheme == 'https',
       verify_mode: OpenSSL::SSL::VERIFY_NONE,
+      ciphers: 'DEFAULT:!DH',
     }
     response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
       http.request(request)
@@ -623,6 +624,7 @@ LOG
     req_options = {
       use_ssl: uri.scheme == "https",
       verify_mode: OpenSSL::SSL::VERIFY_NONE,
+      ciphers: 'DEFAULT:!DH',
     }
     response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
       http.request(request)
@@ -713,6 +715,7 @@ LOG
     req_options = {
       use_ssl: uri.scheme == "https",
       verify_mode: OpenSSL::SSL::VERIFY_NONE,
+      ciphers: 'DEFAULT:!DH',
     }
 
     response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|


### PR DESCRIPTION
 - Allowing clients to request dh can yield to errors like

   OpenSSL::SSL::SSLError:
       SSL_connect returned=1 errno=0 state=error: dh key too small

- By forcing clients to use this mode, servers can't use small keys

- The docker-compose.yml has some outdated notes about how / why to
   set DNS_ALT_NAMES that no longer apply. The hostname specified by
   puppetserver is used when initializing the ca and must be the same
   value other services like puppetdb point to. This is already
   documented well elsewhere.

   The current setup also triggered a bug introduced in the puppetserver
   container at puppetlabs/puppetserver#2327
   that is fixed in puppetlabs/puppetserver#2338

   DNS_ALT_NAMES set to "puppet," worked previously, but then was
   accidentally broken during a refactor. The fix is in the "edge"
   version of the puppetserver container, but hasn't yet reached the
   "latest" version of the container based on packages.

   The "edge" fix has been vetted against the original compose file,
   but since this compose file is really misleading anyhow, adjust it.

 - At some point in the future, all of the open source containers will
   likely use a consistent compose file that's a little different, but
   this change is useful for now
