### PR TITLE
(maint) Switch Travis to Ubuntu 20.04 builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 sudo: required
 
 services:
@@ -6,7 +7,7 @@ services:
 language:
   - ruby
 rvm:
-  - 2.5.5
+  - 2.6.6
 
 env:
   global:


### PR DESCRIPTION
 - Focal fossa time!
 - Make consistent with other pipelines running 19.03
 - Switch to Ruby 2.6.6 for specs, which is known good and installed
 - docker-compose in the 19.03 release included here is 1.23.1, so
   continue to upgrade it on Travis to 1.25.5