### PR TITLE
(maint) Update hadolint to ghcr.io

### DIFF
--- a/gem/ci/build.ps1
+++ b/gem/ci/build.ps1
@@ -50,12 +50,12 @@ function Lint-Dockerfile(
     $Ignore = @())
 {
     $ignores = $Ignore | % { if ($_) { '--ignore', $_ } }
-    Write-Host "& cmd.exe /c docker run --rm -i hadolint/hadolint hadolint $ignores -< $Path"
+    Write-Host "& cmd.exe /c docker run --rm -i ghcr.io/hadolint/hadolint hadolint $ignores -< $Path"
 
     # while a simpler method works locally, there appears to be a bug with stdin in Azure injecting BOMs?
     # https://developercommunity.visualstudio.com/content/problem/451239/powershell-build-step-in-azure-devops-fails-when-p.html
     # https://github.com/microsoft/botbuilder-tools/pull/1046
-    & cmd.exe /c docker run --rm -i hadolint/hadolint hadolint $ignores -< $Path
+    & cmd.exe /c docker run --rm -i ghcr.io/hadolint/hadolint hadolint $ignores -< $Path
     if ($LASTEXITCODE -ne 0) { throw "ERROR: Linting $Path" }
 }
 
@@ -310,9 +310,9 @@ function Write-HostDiagnostics()
     #
     # Linter
     #
-    docker pull hadolint/hadolint:latest
+    docker pull ghcr.io/hadolint/hadolint:latest
     # --pull=always crashes hard in Azure CI agent for some reason
-    docker run --rm hadolint/hadolint:latest hadolint --version
+    docker run --rm ghcr.io/hadolint/hadolint:latest hadolint --version
     #
     # Ruby
     #


### PR DESCRIPTION
 - With hadolint rate limiting, stop using Docker Hub and instead use
   ghcr.io