### PR TITLE
(maint) Update ssl.sh for consistency with k8s

### DIFF
--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -265,14 +265,14 @@ done
 
 ### Get the CA certificate for use with subsequent requests
 ### Fail-fast if openssl errors connecting or the CA certificate can't be parsed
-if ! httpsreq_insecure "$(get "${CA}/certificate/ca")" > "${CACERTFILE}"; then
+if ! retry_httpsreq_insecure "$(get "${CA}/certificate/ca")" 10 > "${CACERTFILE}"; then
     error "cannot reach CA host '${PUPPETSERVER_HOSTNAME}'"
 elif ! openssl x509 -subject -issuer -noout -in "${CACERTFILE}"; then
     error "invalid CA certificate"
 fi
 
 ### Get the CRL from the CA for use with client-side validation
-if ! httpsreq "$(get "${CA}/certificate_revocation_list/ca")" > "${CRLFILE}"; then
+if ! retry_httpsreq "$(get "${CA}/certificate_revocation_list/ca")" 10 > "${CRLFILE}"; then
     error "cannot reach CRL host '${PUPPETSERVER_HOSTNAME}'"
 elif ! openssl crl -text -noout -in "${CRLFILE}" > /dev/null; then
     error "invalid CRL"

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -94,7 +94,7 @@ httpsreq_insecure() {
     [ "${status}" = "200" ] && return 0 || return "$((status))"
 }
 
-master_ca_running() {
+ca_running() {
     test "$(httpsreq_insecure "$(get '/status/v1/simple')")" = "running" && \
         httpsreq_insecure "$(get "${CA}/certificate/ca")" > /dev/null
 }
@@ -192,8 +192,8 @@ if [ -s "${CERTFILE}" ]; then
     exit 0
 fi
 
-msg "Waiting for master ${PUPPETSERVER_HOSTNAME} to be running to generate certificates..."
-while ! master_ca_running; do
+msg "Waiting for ${PUPPETSERVER_HOSTNAME} to be running to generate certificates..."
+while ! ca_running; do
     sleep 1
 done
 

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -252,10 +252,15 @@ ln -s -f "${CERTFILE}" "${CANONICAL_CERTFILE}"
 ln -s -f "${PRIVKEYFILE}" "${CANONICAL_PRIVKEYFILE}"
 ln -s -f "${PUBKEYFILE}" "${CANONICAL_PUBKEYFILE}"
 
+# ensure no error output for empty dir
+certnames=$(cd "${PRIVKEYDIR}" && ls -A -m -- *.pem 2> /dev/null)
 if [ -s "${CERTFILE}" ]; then
-    msg "Certificates have already been generated - exiting!"
+    msg "Certificates (${certnames}) have already been generated - exiting!"
     set_file_perms
     exit 0
+# warn when rekeying an existing host as it's typically user error
+elif [ -n "${certnames}" ]; then
+    msg "Warning: Specified new certificate name ${CERTNAME}, but existing certs (${certnames}) found!"
 fi
 
 msg "Waiting for ${PUPPETSERVER_HOSTNAME} to be running to generate certificates..."

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -117,6 +117,14 @@ ca_running() {
         httpsreq_insecure "$(get "${CA}/certificate/ca")" > /dev/null
 }
 
+set_file_perms() {
+    msg "Securing permissions on ${SSLDIR}"
+
+    # 700 for directories, 600 for files
+    find "${SSLDIR}/." -type d -exec chmod u=rwx,g=,o= -- {} +
+    find "${SSLDIR}/." -type f -exec chmod u=rw,g=,o= -- {} +
+}
+
 ### Verify we got a signed certificate
 verify_cert() {
     if [ -f "${CERTFILE}" ] && [ "$(head -1 "${CERTFILE}")" = "${CERTHEADER}" ]; then
@@ -208,6 +216,7 @@ msg "* WAITFORCERT: '${WAITFORCERT}' seconds"
 
 if [ -s "${CERTFILE}" ]; then
     msg "Certificates have already been generated - exiting!"
+    set_file_perms
     exit 0
 fi
 
@@ -329,5 +338,7 @@ done
 printf "%s\n" "${cert}" > "${CERTFILE}"
 # using a well known filename makes this easier to consume in k8s
 ln -s -f "${CERTFILE}" "${CANONICAL_CERTFILE}"
+
+set_file_perms
 
 verify_cert

--- a/shared/ssl.sh
+++ b/shared/ssl.sh
@@ -155,6 +155,7 @@ PUBKEYFILE="${PUBKEYDIR}/${CERTNAME}.pem"
 CANONICAL_PUBKEYFILE="${PUBKEYDIR}/server.pub"
 PRIVKEYFILE="${PRIVKEYDIR}/${CERTNAME}.pem"
 CANONICAL_PRIVKEYFILE="${PRIVKEYDIR}/server.key"
+CANONICAL_PRIVKEYFILE_PK8="${PRIVKEYDIR}/server.private_key.pk8"
 CSRFILE="${CSRDIR}/${CERTNAME}.pem"
 CERTFILE="${CERTDIR}/${CERTNAME}.pem"
 CANONICAL_CERTFILE="${CERTDIR}/server.crt"
@@ -266,6 +267,10 @@ else
 fi
 # using a well known filename makes this easier to consume in k8s
 ln -s -f "${PRIVKEYFILE}" "${CANONICAL_PRIVKEYFILE}"
+[ -f "${CANONICAL_PRIVKEYFILE_PK8}" ] && rm -rf "${CANONICAL_PRIVKEYFILE_PK8}"
+openssl pkcs8 -topk8 -nocrypt -inform PEM -outform DER \
+    -in "${PRIVKEYFILE}" \
+    -out "${CANONICAL_PRIVKEYFILE_PK8}"
 
 [ -s "${PUBKEYFILE}" ] && msg "recreating existing public key '${PUBKEYFILE}'"
 openssl rsa -in "${PRIVKEYFILE}" -pubout -out "${PUBKEYFILE}"


### PR DESCRIPTION
A number of improvements have been made to the copy of ssl.sh inside the PE k8s chart. Carry those over to this repo as part of moving to a single shared instance of this file.