### PR TITLE
(maint) Update docker-compose --no-ansi for 1.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.25.5
+    - DOCKER_COMPOSE_VERSION=1.28.6
     - COMPOSE_PROJECT_NAME=pupperware
 
 before_install:

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -127,7 +127,7 @@ module SpecHelpers
     file_arg = File.file?(overrides) ? "--file #{overrides}" : ''
     file_arg += ' --file docker-compose.fixtures.yml' if File.file?('docker-compose.fixtures.yml')
     run_command("docker-compose --file docker-compose.yml #{file_arg} \
-                                --no-ansi \
+                                --ansi=never \
                                 #{command_and_args}", stream: stream)
   end
 


### PR DESCRIPTION
- the flag --no-ansi has been deprecated in favor or more specific
 --ansi=(never|always|auto) which requires docker-compose 1.28.0
 release on Jan 20 2021

See https://github.com/docker/compose/pull/6858

Requires all container repos have their compose updated prior to merge

- [x] pe-puppet-server-extensions - https://github.com/puppetlabs/pe-puppet-server-extensions/pull/1288
- [x] pe-console-services - https://github.com/puppetlabs/pe-console-services/pull/358
- [x] pe-orchestration-services - https://github.com/puppetlabs/pe-orchestration-services/pull/262
- [x] pe-puppetdb-extensions - https://github.com/puppetlabs/pe-puppetdb-extensions/pull/636
- [x] pe-bolt-vanagon - https://github.com/puppetlabs/pe-bolt-vanagon/pull/137
- [x] pe-client-tools-vanagon - https://github.com/puppetlabs/pe-client-tools-vanagon/pull/313
- [x] pupperware-commercial - https://github.com/puppetlabs/pupperware-commercial/pull/78
- [x] puppetserver - https://github.com/puppetlabs/puppetserver/pull/2513
- [x] puppetdb - https://github.com/puppetlabs/puppetdb/pull/3446
- [x] r10k - https://github.com/puppetlabs/r10k/pull/1140
- [x] puppet-agent - https://github.com/puppetlabs/puppet-agent/pull/2072
- [x] puppet-runtime - https://github.com/puppetlabs/puppet-runtime/pull/431
- [ ] pupperware - this PR
