### PR TITLE
(maint) generate_rbac_token return token early

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -616,7 +616,9 @@ LOG
     curl('localhost', 4433, end_point).body
   end
 
-  def generate_rbac_token(rbac_username: 'admin', rbac_password: 'pupperware')
+  def generate_rbac_token(rbac_username: 'admin', rbac_password: 'pupperware', force: false)
+    return @rbac_token if @rbac_token && !force
+
     uri = URI.parse("https://localhost:4433/rbac-api/v1/auth/token")
     request = Net::HTTP::Post.new(uri)
     request.content_type = "application/json"


### PR DESCRIPTION
 - If the rbac_token has already been generated, return its cached value
   rather than generating a new token.

   Provide the ability to force create a new one if necessary

   This allows test suites to properly setup a token before making a
   call to wait_for_pxp_agent_to_connect for instance