### PR TITLE
(maint) Use the correct Artifactory image link

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -655,7 +655,7 @@ LOG
         puppetserver: 'puppet',
         pe_console_services: 'pe-console-services',
         pe_orchestration_services: 'pe-orchestration-services',
-        image: 'artifactory.delivery.puppetlabs.net/pe-and-platform/pe-client-tools:latest'
+        image: 'artifactory.delivery.puppetlabs.net/platform-services-297419/pe-and-platform/pe-client-tools:latest'
       )
     run_command("docker pull #{image}")
     run_command("docker run \


### PR DESCRIPTION
 - Publishing has moved to a location in Artifactory that mirrors the
   upstream GCR source of truth. Make sure specs reflect that