### PR TITLE
(REPLATS-188) Fix cert preload impl of CERT_SRCDIR

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -167,7 +167,7 @@ module SpecHelpers
 
     config['services'].each do |service_name, service|
       # for services that have certs
-      source = cert_path.join(service['environment']['CERT_SRCDIR'] || service_name)
+      source = cert_path.join(service.dig('environment', 'CERT_SRCDIR') || service_name)
       next unless source.directory?
 
       # where the first service volume name is a registered volume


### PR DESCRIPTION
- Testing fix in https://github.com/puppetlabs/pe-client-tools-vanagon/pull/315


 - Use safe navigation to look at the services environment IFF it has
   one, rather than always

   Fixes feature introduced in 291cceb