### PR TITLE
Revert "(maint) Update docker-compose --no-ansi for 1.28.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.28.6
+    - DOCKER_COMPOSE_VERSION=1.25.5
     - COMPOSE_PROJECT_NAME=pupperware
     - PRELOAD_CERTS=1
     - PUPPETSERVER_VERSION=edge

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -127,7 +127,7 @@ module SpecHelpers
     file_arg = File.file?(overrides) ? "--file #{overrides}" : ''
     file_arg += ' --file docker-compose.fixtures.yml' if File.file?('docker-compose.fixtures.yml')
     run_command("docker-compose --file docker-compose.yml #{file_arg} \
-                                --ansi=never \
+                                --no-ansi \
                                 #{command_and_args}", stream: stream)
   end
 


### PR DESCRIPTION
Temporarily reverts puppetlabs/pupperware#239

Since these jobs also run on static internal agents for GH actions that haven't yet bumped compose versions, this needs to be reverted for now.