### PR TITLE
(REPLATS-150) Chown the mount point when copying certs

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -204,7 +204,7 @@ module SpecHelpers
       --volume #{src_path}:/tmp/src \
       --volume #{dest_volume}:/opt \
       alpine:3.10 \
-      /bin/sh -c \"cp -r /tmp/src/. /opt/#{dest_dir}; chown -R #{uid}:#{gid} /opt/#{dest_dir}\""
+      /bin/sh -c \"cp -r /tmp/src/. /opt/#{dest_dir}; chown -R #{uid}:#{gid} /opt\""
     STDOUT.puts(<<-MSG)
 Copying existing files through transient container:
   from         : #{src_path}


### PR DESCRIPTION
Previously, the docker_volume_cp helper chowned "/opt/#{dest_dir}",
leaving the /opt directory uid:gid root:root from the container. This
translated into the volume _data dir also being root:root, which was a
problem if the container that would eventually be mounting it was
running as a non-root USER and expected the directory mount to be owned
by USER. Chowning the mount point also keeps the associated volume _data
directory the given uid:gid, allowing us to work around this.