### PR TITLE
(maint) Update docker-compose --no-ansi for 1.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.25.5
+    - DOCKER_COMPOSE_VERSION=1.28.6
     - COMPOSE_PROJECT_NAME=pupperware
     - PRELOAD_CERTS=1
     - PUPPETSERVER_VERSION=edge

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -127,7 +127,7 @@ module SpecHelpers
     file_arg = File.file?(overrides) ? "--file #{overrides}" : ''
     file_arg += ' --file docker-compose.fixtures.yml' if File.file?('docker-compose.fixtures.yml')
     run_command("docker-compose --file docker-compose.yml #{file_arg} \
-                                --no-ansi \
+                                --ansi=never \
                                 #{command_and_args}", stream: stream)
   end
 


### PR DESCRIPTION
Originally landed in #239 - new PR is identical to the original

 - the flag --no-ansi has been deprecated in favor or more specific
   --ansi=(never|always|auto) which requires docker-compose 1.28.0
   release on Jan 20 2021

   See https://github.com/docker/compose/pull/6858

 - Instead of reverting the revert, just introduce a new commit now that ghrunner hosts are updated with a new compose version