### PR TITLE
(REPLATS-174) Upgrade shared postgres to 12.6

### DIFF
--- a/gem/lib/pupperware/compose-services/pe-postgres.yml
+++ b/gem/lib/pupperware/compose-services/pe-postgres.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   postgres:
-    image: ${POSTGRES_IMAGE:-postgres:9.6.15}
+    image: ${POSTGRES_IMAGE:-postgres:12.6}
     hostname: postgres
     environment:
       # to be able to preload certs, PGDATA must be empty when booting, so set

--- a/gem/lib/pupperware/compose-services/postgres.yml
+++ b/gem/lib/pupperware/compose-services/postgres.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   postgres:
-    image: ${POSTGRES_IMAGE:-postgres:9.6}
+    image: ${POSTGRES_IMAGE:-postgres:12.6}
     hostname: postgres
     environment:
       # loading certs requires a non-default PGDATA, even though we don't use certs

--- a/spec/examples/running_cluster.rb
+++ b/spec/examples/running_cluster.rb
@@ -3,8 +3,8 @@ shared_examples 'a running pupperware cluster' do
 
   it 'should include postgres extensions' do
     installed_extensions = get_postgres_extensions
-    expect(installed_extensions).to match(/^\s+pg_trgm\s+/)
-    expect(installed_extensions).to match(/^\s+pgcrypto\s+/)
+    expect(installed_extensions).to match(/\s+pg_trgm\s+/)
+    expect(installed_extensions).to match(/\s+pgcrypto\s+/)
   end
 
   it 'should be able to run an agent' do


### PR DESCRIPTION
Builds on #249

 - In Connect, we're using Postgres 12.6, so start using that for shared service definitions as well.

Validate this works here and in pupperware-commercial prior to merge.