### PR TITLE
(REPLATS-150) Set service uid/gid labels for cert dirs

### DIFF
--- a/gem/lib/pupperware/compose-services/pe-bolt-server.yml
+++ b/gem/lib/pupperware/compose-services/pe-bolt-server.yml
@@ -20,3 +20,7 @@ services:
 
 volumes:
   bolt-server:
+    # Testing specific variable needed to bootstrap cert preloading
+    labels:
+      com.puppet.certs.uid: 10009
+      com.puppet.certs.gid: 10009

--- a/gem/lib/pupperware/compose-services/pe-console-services.yml
+++ b/gem/lib/pupperware/compose-services/pe-console-services.yml
@@ -29,3 +29,7 @@ services:
 
 volumes:
   console-services:
+    # Testing specific variable needed to bootstrap cert preloading
+    labels:
+      com.puppet.certs.uid: 10007
+      com.puppet.certs.gid: 10007

--- a/gem/lib/pupperware/compose-services/pe-orchestration-services.yml
+++ b/gem/lib/pupperware/compose-services/pe-orchestration-services.yml
@@ -28,3 +28,7 @@ services:
 
 volumes:
   orchestration-services:
+    # Testing specific variable needed to bootstrap cert preloading
+    labels:
+      com.puppet.certs.uid: 10009
+      com.puppet.certs.gid: 10009

--- a/gem/lib/pupperware/compose-services/pe-puppet.yml
+++ b/gem/lib/pupperware/compose-services/pe-puppet.yml
@@ -38,5 +38,9 @@ services:
 
 volumes:
   puppetserver:
+    # Testing specific variable needed to bootstrap cert preloading
+    labels:
+      com.puppet.certs.uid: 10006
+      com.puppet.certs.gid: 10006
   puppetserver-packages:
   code-manager:

--- a/gem/lib/pupperware/compose-services/pe-puppetdb.yml
+++ b/gem/lib/pupperware/compose-services/pe-puppetdb.yml
@@ -27,3 +27,7 @@ services:
 
 volumes:
   puppetdb:
+    # Testing specific variable needed to bootstrap cert preloading
+    labels:
+      com.puppet.certs.uid: 10008
+      com.puppet.certs.gid: 10008


### PR DESCRIPTION
The SpecHelpers import preset certs to speed up start up time. To do
this they use a trick of composing the containers with --no-start first
so their entrypoints don't run but volumes are created, then running a
base alpine container with the data dir volume mounted and with the
preset certs mounted, and then copying over the certs and setting
permissions.

All of that is fine, but the act of mounting the datadir in alpine under
/opt (which is owned by root in that container) ends up setting the
host volume path's uid to root as well, which then later interferes with
the container's service user interacting with the datadir when the
actual service container is brought up with the volume mounted.

With this patch, the mount point is instead chowned with the labeled
uid/gid, ensuring the volume root continues to be owned by the service
user. The service ids match those set in the individual service container
repo Dockerfiles.