### PR TITLE
(REPLATS-228) Support generating certificates without containers embedding ssl.sh

### DIFF
--- a/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh
+++ b/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh
@@ -192,13 +192,13 @@ CSRDIR="${SSLDIR}/certificate_requests"
 CERTDIR="${SSLDIR}/certs"
 mkdir -p "${SSLDIR}" "${PUBKEYDIR}" "${PRIVKEYDIR}" "${CSRDIR}" "${CERTDIR}"
 PUBKEYFILE="${PUBKEYDIR}/${CERTNAME}.pem"
-CANONICAL_PUBKEYFILE="${PUBKEYDIR}/server.pub"
+CANONICAL_PUBKEY_FILENAME="server.pub"
 PRIVKEYFILE="${PRIVKEYDIR}/${CERTNAME}.pem"
-CANONICAL_PRIVKEYFILE="${PRIVKEYDIR}/server.key"
+CANONICAL_PRIVKEY_FILENAME="server.key"
 CANONICAL_PRIVKEYFILE_PK8="${PRIVKEYDIR}/server.private_key.pk8"
 CSRFILE="${CSRDIR}/${CERTNAME}.pem"
 CERTFILE="${CERTDIR}/${CERTNAME}.pem"
-CANONICAL_CERTFILE="${CERTDIR}/server.crt"
+CANONICAL_CERT_FILENAME="server.crt"
 CACERTFILE="${CERTDIR}/ca.pem"
 CRLFILE="${SSLDIR}/crl.pem"
 ALTNAMEFILE="/tmp/altnames.conf"
@@ -248,9 +248,10 @@ msg "* WAITFORCERT: '${WAITFORCERT}' seconds"
 
 # generate all symlinks, even if targets don't exist yet
 # using well known filenames makes these easier to consume in k8s
-ln -s -f "${CERTFILE}" "${CANONICAL_CERTFILE}"
-ln -s -f "${PRIVKEYFILE}" "${CANONICAL_PRIVKEYFILE}"
-ln -s -f "${PUBKEYFILE}" "${CANONICAL_PUBKEYFILE}"
+# also use relative symlinks rather than absolute to ease sharing across differently mounted container volumes
+(cd "${CERTDIR}" && ln -s -f "${CERTNAME}.pem" "${CANONICAL_CERT_FILENAME}")
+(cd "${PRIVKEYDIR}" && ln -s -f "${CERTNAME}.pem" "${CANONICAL_PRIVKEY_FILENAME}")
+(cd "${PUBKEYDIR}" && ln -s -f "${CERTNAME}.pem" "${CANONICAL_PUBKEY_FILENAME}")
 
 # ensure no error output for empty dir
 certnames=$(cd "${PRIVKEYDIR}" && ls -A -m -- *.pem 2> /dev/null)

--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -154,10 +154,12 @@ module SpecHelpers
     YAML.safe_load(docker_compose('config')[:stdout].chomp)
   end
 
-  def docker_compose_up(preload_certs: true)
+  def docker_compose_up(preload_certs: true, ca_service_name: 'puppet')
     docker_compose('config', stream: STDOUT)
     docker_compose('up --no-start', stream: STDOUT)
-    docker_compose_load_cert_volumes(preload_certs: preload_certs)
+    # generating certs requires running CA
+    docker_compose("start #{ca_service_name}", stream: STDOUT) if !preload_certs
+    docker_compose_load_cert_volumes(preload_certs: preload_certs, ca_service_name: ca_service_name)
     docker_compose('up --detach', stream: STDOUT)
     docker_compose('images', stream: STDOUT)
     wait_on_stack_healthy()
@@ -178,7 +180,7 @@ module SpecHelpers
     run_command('docker ps --all')
   end
 
-  def docker_compose_load_cert_volumes(preload_certs: true)
+  def docker_compose_load_cert_volumes(preload_certs: true, ca_service_name: 'puppet')
     config = docker_compose_config()
     # list of available certs for services
     cert_path = Pathname.new(File.join(__dir__, 'certs'))
@@ -204,6 +206,21 @@ module SpecHelpers
         docker_volume_cp(src_path: source, dest_volume: volume, dest_dir: dest_dir,
           uid: labels ? labels['com.puppet.certs.uid'] : nil,
           gid: labels ? labels['com.puppet.certs.gid'] : nil)
+      else
+        certname = service['environment']['CERTNAME']
+        if certname.nil?
+          STDOUT.puts("[WARN] Skipping certificate generation for service #{service_name} - no CERTNAME specified")
+          next
+        end
+        dns_alt_names = service['environment']['DNS_ALT_NAMES'] || certname
+        STDOUT.puts("Generating certificates for service #{service_name}")
+          generate_certificate(
+            ca_service_name: ca_service_name,
+            certname: certname,
+            dns_alt_names: dns_alt_names,
+            dest_volume: volume, dest_dir: dest_dir,
+            uid: labels ? labels['com.puppet.certs.uid'] : nil,
+            gid: labels ? labels['com.puppet.certs.gid'] : nil)
       end
     end
   end
@@ -235,6 +252,38 @@ MSG
     result = run_command(cmd)
     if result[:status].exitstatus != 0
       raise "docker_volume_cp failed to '#{dest_volume}/#{dest_dir}' #{result[:status].exitstatus}:\n#{result[:stdout].chomp}"
+    end
+  end
+
+  # takes a given certname, and generates certs to the dest_dir of dest_volume
+  # uses a transient container with 00-ssl.sh mapped into it to generate certs
+  def generate_certificate(ca_service_name:, certname:, dns_alt_names:, dest_volume:, dest_dir:, is_compose: true, uid:, gid: )
+    uid ||= 'root'
+    gid ||= 'root'
+    if is_compose
+      prefix = ENV['COMPOSE_PROJECT_NAME'] || File.basename(Dir.pwd)
+      dest_volume = "#{prefix}_#{dest_volume}"
+    end
+    # create a temp container that generates certs to the appropriate volume
+    ca_container = get_service_container(ca_service_name)
+    ssl_src_path = Pathname.new(File.join(__dir__, 'compose-services', 'pe-postgres-custom'))
+    cmd = "docker run \
+      --rm \
+      --network #{get_container_network(ca_container)} \
+      --volume #{ssl_src_path}:/tmp/ssl \
+      --volume #{dest_volume}:/opt \
+      --entrypoint /bin/sh \
+      alpine/openssl \
+      -c \"SSLDIR=/opt/#{dest_dir} PUPPETSERVER_HOSTNAME=#{get_container_hostname(ca_container)} CERTNAME=#{certname} DNS_ALT_NAMES=#{dns_alt_names} /tmp/ssl/00-ssl.sh; chown -R #{uid}:#{gid} /opt\""
+    STDOUT.puts(<<-MSG)
+Generating new certificates with transient container using ssl.sh:
+  certname      : #{certname}
+  to volume     : #{dest_volume}/#{dest_dir}
+  with uid:gid  : #{uid}:#{gid}
+MSG
+    result = run_command(cmd)
+    if result[:status].exitstatus != 0
+      raise "generate_certificate failed to '#{dest_volume}/#{dest_dir}' #{result[:status].exitstatus}:\n#{result[:stdout].chomp}"
     end
   end
 


### PR DESCRIPTION
This is the last important part of the puzzle necessary to removing ssl.sh from PE containers. It should be vetted in a test PR to pe-puppet-server-extensions prior to merging here (puppetserver tests only have a single node / compiler, so don't actually generate certs yet useful for testing this PR)

- [x] pe-puppet-server-extensions - https://github.com/puppetlabs/pe-puppet-server-extensions/pull/1293


- To be able to remove ssl.sh from all PE containers, the testing
   suites should still have the option of generating certificates to
   exerise the CA, rather than preloading well-known certs. This is
   important for at least the puppetserver suites.

   Attach a transient alpine/openssl container and load the 00-ssl.sh
   script into it, attaching it to container volumes in exactly the same
   way that cert preloading works. Instead of copying files, run the
   script with the correct values to generate certs against the CA -
   namely SSLDIR, CERTNAME, DNS_ALT_NAMES and PUPPETSERVER_HOSTNAME.

   Services defined in docker-compose that are missing the CERTNAME
   value are skipped as they don't need certs generated. This allows for
   easily skipping puppetserver itself *or* other test fixtures that
   may be defined.

 - Makes a minor fix to the ssl.sh script to make symlinks to canonical
   cert files relative rather than absolute. When the files are
   generated in a different container with a different path within the
   volume, absolute paths may result in dangling symlinks when files are
   accessed in the destination container. This can lead to problems
   performing chmod / chown and other file access operations.