### PR TITLE
(REPLATS-101) Add curl_pe_rbac_services helper

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -622,13 +622,17 @@ LOG
   end
 
   ######################################################################
-  # PE Console Services Helper
+  # PE RBAC / Console Services Helper
   ######################################################################
 
   def unrevoke_console_admin_user(postgres_container_name = "postgres")
     query = "exec -T #{postgres_container_name} psql --username=puppetdb --dbname=pe-rbac --command \"UPDATE subjects SET is_revoked = 'f' WHERE login='admin';\""
     output = docker_compose(query)[:stdout].chomp
     raise('failed to unrevoke the admin account') if ! output.eql? "UPDATE 1"
+  end
+
+  def curl_pe_rbac_services(end_point)
+    curl('localhost', 4434, end_point).body
   end
 
   def curl_pe_console_services(end_point)


### PR DESCRIPTION
 - RBAC services container will be mapped to localhost when running
   docker-compose at port 4434, while keeping existing console services
   apis (activity service and classifier) at 4433. This is the easiest
   approach for not introducing a number of breaking changes to specs
   in multiple projects.

   This will be merged prior to landing the refactor to two containers
   in pe-console-services