### PR TITLE
(maint) Remove ADMIN_RBAC_PASSWORD from orch

### DIFF
--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -133,7 +133,6 @@ The following values, many of which are already overriden in the `docker-compose
 | **PE_BOLT_SERVER_HOSTNAME**             | The DNS hostname of the pe-bolt-server service<br><br>`pe-bolt-server`                                                                                                             |
 | **PE_ACE_SERVER_HOSTNAME**              | The DNS hostname of the ace-server service<br><br>`ace`                                                                                                                            |
 | **PE_CONSOLE_SERVICES_HOSTNAME**        | The DNS hostname of the pe-console-services service<br><br>`pe-console-services`                                                                                                   |
-| **ADMIN_RBAC_PASSWORD**                 | Log into the PE console using the username `admin` and this password value, once all containers are healthy<br><br>`admin`                                                         |
 | **PE_ORCHESTRATION_SERVICES_LOG_LEVEL** | The logging level to use for this service<br><br>`info`                                                                                                                            |
 | **PE_ORCHESTRATION_SERVICES_JAVA_ARGS** | Arguments passed directly to the JVM when starting the service<br><br>`-Xmx1g`                                                                                                     |
 


### PR DESCRIPTION
- Relates to https://github.com/puppetlabs/pe-orchestration-services/pull/269

 - This mechanism for setting the console password has been removed
   and pe-orchestration-services container is no longer responsible for
   running a script to set the console password. If anything, this
   functionality should be rolled into the pe-client-tools container
   alongside ssl.sh, but for now, it is not rehomed anywhere.

   k8s does not use the functionality, nor do any of the docker-compose
   based testing suites. All have been updated to programatically set
   the password in tests where necessary.

   Since docker-compose will never be shipped to end users, a k8s
   solution in a job / initContainer will be the long-term solution
   until theres an ability to set the console password on boot for
   console services.