### PR TITLE
(maint) Change ssl.sh interpreter to Bash

### DIFF
--- a/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh
+++ b/gem/lib/pupperware/compose-services/pe-postgres-custom/00-ssl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Get a signed certificate for this host.
 #


### PR DESCRIPTION
 - While the shell script here is compatible with /bin/sh for historical
   reasons, there are some reasons to use /bin/bash - for instance,
   set -o pipefail

   This impacts consumers like Connect / Cygnus and the PE Helm chart
   work.

   Since we no longer care much about Alpine linux and using strictly
   POSIX, change the default interpreter.

 - An update will be made to pe-client-tools container to incorporate
   the updated version of this script