### PR TITLE
(PE-32949) Explicitly run test cert gen script via `/bin/sh`

### DIFF
--- a/gem/lib/pupperware/spec_helper.rb
+++ b/gem/lib/pupperware/spec_helper.rb
@@ -286,7 +286,7 @@ MSG
       --volume #{dest_volume}:/opt \
       --entrypoint /bin/sh \
       alpine/openssl \
-      -c \"SSLDIR=/opt/#{dest_dir} PUPPETSERVER_HOSTNAME=#{get_container_hostname(ca_container)} CERTNAME=#{certname} DNS_ALT_NAMES=#{dns_alt_names} /tmp/ssl/00-ssl.sh; chown -R #{uid}:#{gid} /opt\""
+      -c \"SSLDIR=/opt/#{dest_dir} PUPPETSERVER_HOSTNAME=#{get_container_hostname(ca_container)} CERTNAME=#{certname} DNS_ALT_NAMES=#{dns_alt_names} /bin/sh /tmp/ssl/00-ssl.sh; chown -R #{uid}:#{gid} /opt\""
     STDOUT.puts(<<-MSG)
 Generating new certificates with transient container using ssl.sh:
   certname      : #{certname}


### PR DESCRIPTION
We have a script that is used the in pe-puppet-server-extensions
container tests to generate certs for specific certs names. It is run in
an ephemeral container, based on the `alpine/openssl` image. When the
script was updated to run under bash, the helper to run it in the temp
container broke, because bash is not available in alpine. This commit
updates that docker invocation to explicitly run the script in `sh`.