### PR TITLE
(maint) Explicitly depend on thwait

### DIFF
--- a/gem/pupperware.gemspec
+++ b/gem/pupperware.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency 'thwait', '~> 0.2'
 end


### PR DESCRIPTION
Ruby 2.7 stopped shipping thwait bundled inside Ruby and made it a
standalone gem. This commit adds thwait as an explicit dependency, so we
can make sure we always install it.