### PR TITLE
Update bin/puppet to support more failure modes

### DIFF
--- a/bin/puppet
+++ b/bin/puppet
@@ -1,5 +1,33 @@
-#! /bin/sh
+#! /bin/bash
 
-cd "$(dirname "$0")/.." || exit 1
+FILE="$0"
 
-docker-compose exec puppet puppet "$@"
+if [ "$(echo "$0" | cut -d/ -f1)" == "$0" ]
+then
+	if [ ! -e "$0" ]
+	then
+		FILE="$(which "$0")"
+	fi
+fi
+
+cd "$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$FILE")")/.." || exit 1
+
+if docker info > /dev/null 2>/dev/null
+then
+	export ADDITIONAL_COMPOSE_SERVICES_PATH=${PWD}/gem/lib/pupperware/compose-services
+	export COMPOSE_FILE=${ADDITIONAL_COMPOSE_SERVICES_PATH}/postgres.yml:${ADDITIONAL_COMPOSE_SERVICES_PATH}/puppetdb.yml:${ADDITIONAL_COMPOSE_SERVICES_PATH}/puppet.yml
+
+	if command -v docker >/dev/null 2>/dev/null && docker compose version > /dev/null 2>/dev/null
+	then
+		docker compose exec puppet puppet "$@"
+	elif command -v docker-compose >/dev/null 2>/dev/null && docker-compose version > /dev/null 2>/dev/null
+	then
+		docker-compose exec puppet puppet "$@"
+	else
+		echo "No access to 'docker compose' or 'docker-compose'. Please fix to continue."
+		exit 2
+	fi
+else
+	echo "No permissions. Are you in the docker group, or root?"
+	exit 1
+fi

--- a/bin/puppetserver
+++ b/bin/puppetserver
@@ -1,5 +1,33 @@
-#! /bin/sh
+#! /bin/bash
 
-cd "$(dirname "$0")/.." || exit 1
+FILE="$0"
 
-docker-compose exec puppet puppetserver "$@"
+if [ "$(echo "$0" | cut -d/ -f1)" == "$0" ]
+then
+	if [ ! -e "$0" ]
+	then
+		FILE="$(which "$0")"
+	fi
+fi
+
+cd "$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$FILE")")/.." || exit 1
+
+if docker info > /dev/null 2>/dev/null
+then
+	export ADDITIONAL_COMPOSE_SERVICES_PATH=${PWD}/gem/lib/pupperware/compose-services
+	export COMPOSE_FILE=${ADDITIONAL_COMPOSE_SERVICES_PATH}/postgres.yml:${ADDITIONAL_COMPOSE_SERVICES_PATH}/puppetdb.yml:${ADDITIONAL_COMPOSE_SERVICES_PATH}/puppet.yml
+
+	if command -v docker >/dev/null 2>/dev/null && docker compose version > /dev/null 2>/dev/null
+	then
+		docker compose exec puppet puppetserver "$@"
+	elif command -v docker-compose >/dev/null 2>/dev/null && docker-compose version > /dev/null 2>/dev/null
+	then
+		docker-compose exec puppet puppetserver "$@"
+	else
+		echo "No access to 'docker compose' or 'docker-compose'. Please fix to continue."
+		exit 2
+	fi
+else
+	echo "No permissions. Are you in the docker group, or root?"
+	exit 1
+fi

--- a/gem/lib/pupperware/compose-services/puppet.yml
+++ b/gem/lib/pupperware/compose-services/puppet.yml
@@ -22,8 +22,8 @@ services:
       - CERT_SRCDIR=puppet-oss
       - CERT_DESTDIR=ssl
     volumes:
-      - puppetserver-code:/etc/puppetlabs/code/
-      - puppetserver-config:/etc/puppetlabs/puppet/
+      - ./puppetserver-code:/etc/puppetlabs/code/
+      - ./puppetserver-config:/etc/puppetlabs/puppet/
       - puppetserver-ca:/etc/puppetlabs/puppetserver/ca
       - puppetserver-data:/opt/puppetlabs/server/data/puppetserver/
     restart: always
@@ -32,7 +32,5 @@ services:
       - 8170:8170
 
 volumes:
-  puppetserver-code:
-  puppetserver-config:
   puppetserver-ca:
   puppetserver-data:


### PR DESCRIPTION
* Test for whether this script is being run as a symlink, and follow the symlink to it's source
* Test for whether `docker-compose` or `docker-compose-plugin` is installed
* Ensure that the required paths are loaded
* Test that you have permissions to run docker commands